### PR TITLE
refactor: bilibili-share-to-friends 下沉弹窗组件状态

### DIFF
--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -3,3 +3,4 @@ export * from "./dom.js";
 export * from "./route.js";
 export * from "./storage.js";
 export * from "./style.js";
+export * from "./timing.js";

--- a/packages/shared/src/timing.js
+++ b/packages/shared/src/timing.js
@@ -1,0 +1,9 @@
+export const debounce = (callback, delay) => {
+  let timer = null;
+  const debounced = (...args) => {
+    globalThis.clearTimeout(timer);
+    timer = globalThis.setTimeout(() => callback(...args), delay);
+  };
+  debounced.cancel = () => globalThis.clearTimeout(timer);
+  return debounced;
+};

--- a/packages/shared/test/timing.test.js
+++ b/packages/shared/test/timing.test.js
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { debounce } from "../src/index.js";
+
+const wait = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
+
+test("debounce runs only the last scheduled call", async () => {
+  const calls = [];
+  const debounced = debounce((value) => calls.push(value), 5);
+
+  debounced("first");
+  debounced("second");
+  await wait(10);
+
+  assert.deepEqual(calls, ["second"]);
+});
+
+test("debounce cancel prevents a pending call", async () => {
+  const calls = [];
+  const debounced = debounce((value) => calls.push(value), 5);
+
+  debounced("ignored");
+  debounced.cancel();
+  await wait(10);
+
+  assert.deepEqual(calls, []);
+});

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -272,44 +272,26 @@ export const AllFriendsPanel = ({
     }, 300);
   };
 
-  const renderUsers = ({
-    users,
-    emptyText,
-    hasMore = false,
-    loadingMore = false,
-    moreError = "",
-    onRetry = () => {},
-  }) => {
-    const userList = (
-      <UserList
-        users={users}
-        selectedMid={selectedMid}
-        hasMore={hasMore}
-        loadingMore={loadingMore}
-        moreError={moreError}
-        showFooter
-        onRetry={onRetry}
-        onSelect={onSelect}
-      />
-    );
-
-    if (users.length === 0) {
-      return (
-        <>
-          <StateView text={emptyText} />
-          {userList}
-        </>
-      );
-    }
-    return userList;
-  };
-
   if (!active) {
     return null;
   }
 
   const keyword = searchTerm.trim();
   const displayState = getRelationDisplayState(relations, activeRelation, searchTerm);
+  const displayUsers = getRelationDisplayUsers(relations, activeRelation, searchTerm);
+  const emptyText = activeRelation === "following" ? "暂无关注用户。" : "暂无粉丝用户。";
+  const userList = (
+    <UserList
+      users={displayUsers}
+      selectedMid={selectedMid}
+      hasMore={displayState.hasMore}
+      loadingMore={displayState.loadingMore}
+      moreError={displayState.moreError}
+      showFooter
+      onRetry={() => loadRelationUsers(activeRelation)}
+      onSelect={onSelect}
+    />
+  );
 
   return (
     <div ref={panelRef}>
@@ -339,15 +321,13 @@ export const AllFriendsPanel = ({
         <StateView text="正在读取用户列表..." />
       ) : displayState.error ? (
         <StateView text={displayState.error} isError />
+      ) : displayUsers.length === 0 ? (
+        <>
+          <StateView text={emptyText} />
+          {userList}
+        </>
       ) : (
-        renderUsers({
-          users: getRelationDisplayUsers(relations, activeRelation, searchTerm),
-          emptyText: activeRelation === "following" ? "暂无关注用户。" : "暂无粉丝用户。",
-          hasMore: displayState.hasMore,
-          loadingMore: displayState.loadingMore,
-          moreError: displayState.moreError,
-          onRetry: () => loadRelationUsers(activeRelation),
-        })
+        userList
       )}
     </div>
   );

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
+import { debounce } from "@tampermonkey-scripts/shared";
 
 import { getFollowers, getFollowings, searchFollowings } from "../../api.js";
 import { LIST_SCROLL_SELECTOR } from "../../constants.js";
@@ -36,11 +37,11 @@ export const AllFriendsPanel = ({
 }) => {
   const panelRef = useRef(null);
   const stateRef = useRef(null);
-  const searchTimerRef = useRef(null);
   const loadMoreObserverRef = useRef(null);
   const loadingKeysRef = useRef(new Set());
   const pendingScrollTopRef = useRef(null);
   const searchComposingRef = useRef({ value: false });
+  const debouncedSearchRef = useRef(null);
   const [activeRelation, setActiveRelation] = useState("following");
   const [searchTerm, setSearchTerm] = useState("");
   const [relations, setRelations] = useState(createRelationsState);
@@ -79,7 +80,7 @@ export const AllFriendsPanel = ({
 
   useEffect(() => {
     return () => {
-      window.clearTimeout(searchTimerRef.current);
+      debouncedSearchRef.current?.cancel();
       loadMoreObserverRef.current?.disconnect();
     };
   }, []);
@@ -204,6 +205,15 @@ export const AllFriendsPanel = ({
     [getListScrollTop, setPageState]
   );
 
+  if (!debouncedSearchRef.current) {
+    debouncedSearchRef.current = debounce((nextKeyword) => {
+      const current = stateRef.current;
+      if (current.activeRelation === "following" && nextKeyword) {
+        loadRelationUsers("following", { reset: true, keywordOverride: nextKeyword });
+      }
+    }, 300);
+  }
+
   useEffect(() => {
     if (active) {
       loadRelationUsers(activeRelation);
@@ -258,13 +268,7 @@ export const AllFriendsPanel = ({
     if (previousKeyword || nextKeyword) {
       resetSelection();
     }
-    window.clearTimeout(searchTimerRef.current);
-    searchTimerRef.current = window.setTimeout(() => {
-      const current = stateRef.current;
-      if (current.activeRelation === "following" && nextKeyword) {
-        loadRelationUsers("following", { reset: true, keywordOverride: nextKeyword });
-      }
-    }, 300);
+    debouncedSearchRef.current(nextKeyword);
   };
 
   if (!active) {
@@ -317,7 +321,7 @@ export const AllFriendsPanel = ({
             : ""
         }
         composing={searchComposingRef.current}
-        onCompositionStart={() => window.clearTimeout(searchTimerRef.current)}
+        onCompositionStart={() => debouncedSearchRef.current?.cancel()}
         onInput={scheduleSearch}
       />
       {renderListContent()}

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -272,18 +272,6 @@ export const AllFriendsPanel = ({
   }
 
   const emptyText = activeRelation === "following" ? "暂无关注用户。" : "暂无粉丝用户。";
-  const userList = (
-    <UserList
-      users={displayUsers}
-      selectedMid={selectedMid}
-      hasMore={displayState.hasMore}
-      loadingMore={displayLoading.loadingMore}
-      moreError={displayState.moreError}
-      showFooter
-      onRetry={() => loadRelationUsers(activeRelation)}
-      onSelect={onSelect}
-    />
-  );
   const renderListContent = () => {
     if (displayLoading.loading) {
       return <StateView text="正在读取用户列表..." />;
@@ -294,7 +282,18 @@ export const AllFriendsPanel = ({
     if (displayUsers.length === 0) {
       return <StateView text={emptyText} />;
     }
-    return userList;
+    return (
+      <UserList
+        users={displayUsers}
+        selectedMid={selectedMid}
+        hasMore={displayState.hasMore}
+        loadingMore={displayLoading.loadingMore}
+        moreError={displayState.moreError}
+        showFooter
+        onRetry={() => loadRelationUsers(activeRelation)}
+        onSelect={onSelect}
+      />
+    );
   };
 
   return (

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -292,12 +292,7 @@ export const AllFriendsPanel = ({
       return <StateView text={displayState.error} isError />;
     }
     if (displayUsers.length === 0) {
-      return (
-        <>
-          <StateView text={emptyText} />
-          {userList}
-        </>
-      );
+      return <StateView text={emptyText} />;
     }
     return userList;
   };

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -287,6 +287,23 @@ export const AllFriendsPanel = ({
       onSelect={onSelect}
     />
   );
+  const renderListContent = () => {
+    if (displayState.loading) {
+      return <StateView text="正在读取用户列表..." />;
+    }
+    if (displayState.error) {
+      return <StateView text={displayState.error} isError />;
+    }
+    if (displayUsers.length === 0) {
+      return (
+        <>
+          <StateView text={emptyText} />
+          {userList}
+        </>
+      );
+    }
+    return userList;
+  };
 
   return (
     <div ref={panelRef}>
@@ -312,18 +329,7 @@ export const AllFriendsPanel = ({
         onCompositionStart={() => window.clearTimeout(searchTimerRef.current)}
         onInput={scheduleSearch}
       />
-      {displayState.loading ? (
-        <StateView text="正在读取用户列表..." />
-      ) : displayState.error ? (
-        <StateView text={displayState.error} isError />
-      ) : displayUsers.length === 0 ? (
-        <>
-          <StateView text={emptyText} />
-          {userList}
-        </>
-      ) : (
-        userList
-      )}
+      {renderListContent()}
     </div>
   );
 };

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
 
 import { getFollowers, getFollowings, searchFollowings } from "../../api.js";
 import { LIST_SCROLL_SELECTOR } from "../../constants.js";
@@ -34,27 +34,6 @@ const createRelationsState = () => ({
   followers: createEmptyRelationState(),
 });
 
-const getRelationDisplayState = (relations, relation, searchTerm) => {
-  const relationState = relations[relation];
-  const keyword = searchTerm.trim();
-  if (relation === "following" && keyword) {
-    return relationState.search;
-  }
-  return relationState;
-};
-
-const getRelationDisplayUsers = (relations, relation, searchTerm) => {
-  const relationState = relations[relation];
-  const keyword = searchTerm.trim().toLowerCase();
-  if (!keyword) {
-    return relationState.users;
-  }
-  if (relation === "following") {
-    return relationState.search.users;
-  }
-  return relationState.users.filter((user) => user.name.toLowerCase().includes(keyword));
-};
-
 const updateRelationDisplayState = (relations, relation, useSearch, updater) => {
   const relationState = relations[relation];
   return {
@@ -85,6 +64,26 @@ export const AllFriendsPanel = ({
   const [activeRelation, setActiveRelation] = useState("following");
   const [searchTerm, setSearchTerm] = useState("");
   const [relations, setRelations] = useState(createRelationsState);
+  const keyword = searchTerm.trim();
+  const normalizedKeyword = keyword.toLowerCase();
+  const relationState = relations[activeRelation];
+  const displayState = useMemo(() => {
+    if (activeRelation === "following" && keyword) {
+      return relationState.search;
+    }
+    return relationState;
+  }, [activeRelation, keyword, relationState]);
+  const displayUsers = useMemo(() => {
+    if (!normalizedKeyword) {
+      return relationState.users;
+    }
+    if (activeRelation === "following") {
+      return relationState.search.users;
+    }
+    return relationState.users.filter((user) =>
+      user.name.toLowerCase().includes(normalizedKeyword)
+    );
+  }, [activeRelation, normalizedKeyword, relationState]);
 
   stateRef.current = {
     activeRelation,
@@ -227,7 +226,6 @@ export const AllFriendsPanel = ({
     if (!active) {
       return;
     }
-    const displayState = getRelationDisplayState(relations, activeRelation, searchTerm);
     if (!displayState.hasMore || displayState.loading || displayState.loadingMore) {
       return;
     }
@@ -247,7 +245,7 @@ export const AllFriendsPanel = ({
     observer.observe(sentinel);
     loadMoreObserverRef.current = observer;
     return () => observer.disconnect();
-  }, [active, activeRelation, loadRelationUsers, relations, searchTerm]);
+  }, [active, activeRelation, displayState, loadRelationUsers]);
 
   const resetSelection = () => {
     onSelectionReset();
@@ -276,9 +274,6 @@ export const AllFriendsPanel = ({
     return null;
   }
 
-  const keyword = searchTerm.trim();
-  const displayState = getRelationDisplayState(relations, activeRelation, searchTerm);
-  const displayUsers = getRelationDisplayUsers(relations, activeRelation, searchTerm);
   const emptyText = activeRelation === "following" ? "暂无关注用户。" : "暂无粉丝用户。";
   const userList = (
     <UserList

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -7,45 +7,25 @@ import { SearchBox } from "../search-box/SearchBox.jsx";
 import { StateView } from "../state-view/StateView.jsx";
 import { UserList } from "../user-list/UserList.jsx";
 
-const createEmptyRelationState = () => ({
+const createPageState = () => ({
   users: [],
   page: 0,
   hasMore: true,
-  loading: false,
-  loadingMore: false,
+  loadingPage: 0,
   moreError: "",
   error: "",
   loaded: false,
-  search: {
-    users: [],
-    page: 0,
-    hasMore: true,
-    loading: false,
-    loadingMore: false,
-    moreError: "",
-    error: "",
-    loaded: false,
-    keyword: "",
-  },
 });
 
 const createRelationsState = () => ({
-  following: createEmptyRelationState(),
-  followers: createEmptyRelationState(),
+  following: createPageState(),
+  followers: createPageState(),
 });
 
-const updateRelationDisplayState = (relations, relation, useSearch, updater) => {
-  const relationState = relations[relation];
-  return {
-    ...relations,
-    [relation]: useSearch
-      ? {
-          ...relationState,
-          search: updater(relationState.search),
-        }
-      : updater(relationState),
-  };
-};
+const getPageLoadingState = (state) => ({
+  loading: state.loadingPage > 0 && (state.loadingPage === 1 || !state.loaded),
+  loadingMore: state.loadingPage > 0 && state.loaded && state.loadingPage > 1,
+});
 
 export const AllFriendsPanel = ({
   active,
@@ -64,31 +44,36 @@ export const AllFriendsPanel = ({
   const [activeRelation, setActiveRelation] = useState("following");
   const [searchTerm, setSearchTerm] = useState("");
   const [relations, setRelations] = useState(createRelationsState);
+  const [followingSearch, setFollowingSearch] = useState(createPageState);
   const keyword = searchTerm.trim();
   const normalizedKeyword = keyword.toLowerCase();
+  const displaySource =
+    activeRelation === "following" && keyword ? "followingSearch" : activeRelation;
   const relationState = relations[activeRelation];
   const displayState = useMemo(() => {
-    if (activeRelation === "following" && keyword) {
-      return relationState.search;
+    if (displaySource === "followingSearch") {
+      return followingSearch;
     }
     return relationState;
-  }, [activeRelation, keyword, relationState]);
+  }, [displaySource, followingSearch, relationState]);
+  const displayLoading = useMemo(() => getPageLoadingState(displayState), [displayState]);
   const displayUsers = useMemo(() => {
     if (!normalizedKeyword) {
       return relationState.users;
     }
     if (activeRelation === "following") {
-      return relationState.search.users;
+      return followingSearch.users;
     }
     return relationState.users.filter((user) =>
       user.name.toLowerCase().includes(normalizedKeyword)
     );
-  }, [activeRelation, normalizedKeyword, relationState]);
+  }, [activeRelation, followingSearch.users, normalizedKeyword, relationState]);
 
   stateRef.current = {
     activeRelation,
     searchTerm,
     relations,
+    followingSearch,
     mid,
   };
 
@@ -103,6 +88,7 @@ export const AllFriendsPanel = ({
     setActiveRelation("following");
     setSearchTerm("");
     setRelations(createRelationsState());
+    setFollowingSearch(createPageState());
     onSelectionReset();
   }, [mid, onSelectionReset]);
 
@@ -123,10 +109,15 @@ export const AllFriendsPanel = ({
     []
   );
 
-  const setDisplayState = useCallback((relation, useSearch, updater) => {
-    setRelations((currentRelations) =>
-      updateRelationDisplayState(currentRelations, relation, useSearch, updater)
-    );
+  const setPageState = useCallback((source, updater) => {
+    if (source === "followingSearch") {
+      setFollowingSearch(updater);
+      return;
+    }
+    setRelations((currentRelations) => ({
+      ...currentRelations,
+      [source]: updater(currentRelations[source]),
+    }));
   }, []);
 
   const loadRelationUsers = useCallback(
@@ -134,15 +125,17 @@ export const AllFriendsPanel = ({
       const current = stateRef.current;
       const keyword = (keywordOverride ?? current.searchTerm).trim();
       const useSearch = relation === "following" && Boolean(keyword);
+      const source = useSearch ? "followingSearch" : relation;
       const relationState = current.relations[relation];
-      const displayState = useSearch ? relationState.search : relationState;
+      const displayState = useSearch ? current.followingSearch : relationState;
+      const loadingState = getPageLoadingState(displayState);
       const loadingKey = `${relation}:${useSearch ? keyword : "list"}`;
 
       if (
         !current.mid ||
         loadingKeysRef.current.has(loadingKey) ||
-        displayState.loading ||
-        displayState.loadingMore ||
+        loadingState.loading ||
+        loadingState.loadingMore ||
         (!reset && displayState.loaded && !displayState.hasMore)
       ) {
         return;
@@ -152,13 +145,11 @@ export const AllFriendsPanel = ({
       const listScrollTop = !reset && displayState.loaded ? getListScrollTop() : null;
       pendingScrollTopRef.current = listScrollTop;
       loadingKeysRef.current.add(loadingKey);
-      setDisplayState(relation, useSearch, (state) => ({
+      setPageState(source, (state) => ({
         ...state,
-        loading: reset || !state.loaded,
-        loadingMore: !(reset || !state.loaded),
+        loadingPage: nextPage,
         error: "",
         moreError: "",
-        keyword: useSearch ? keyword : state.keyword,
       }));
 
       try {
@@ -172,7 +163,7 @@ export const AllFriendsPanel = ({
           keyword,
           page: nextPage,
         });
-        setDisplayState(relation, useSearch, (state) => ({
+        setPageState(source, (state) => ({
           ...state,
           users: nextPage === 1 ? nextResult.users : [...state.users, ...nextResult.users],
           page: nextPage,
@@ -180,7 +171,7 @@ export const AllFriendsPanel = ({
           loaded: true,
         }));
       } catch (loadError) {
-        setDisplayState(relation, useSearch, (state) => {
+        setPageState(source, (state) => {
           if (useSearch && nextPage === 1) {
             return {
               ...state,
@@ -204,14 +195,13 @@ export const AllFriendsPanel = ({
         });
       } finally {
         loadingKeysRef.current.delete(loadingKey);
-        setDisplayState(relation, useSearch, (state) => ({
+        setPageState(source, (state) => ({
           ...state,
-          loading: false,
-          loadingMore: false,
+          loadingPage: 0,
         }));
       }
     },
-    [getListScrollTop, setDisplayState]
+    [getListScrollTop, setPageState]
   );
 
   useEffect(() => {
@@ -226,7 +216,7 @@ export const AllFriendsPanel = ({
     if (!active) {
       return;
     }
-    if (!displayState.hasMore || displayState.loading || displayState.loadingMore) {
+    if (!displayState.hasMore || displayLoading.loading || displayLoading.loadingMore) {
       return;
     }
     const scrollRoot = panelRef.current?.querySelector(LIST_SCROLL_SELECTOR);
@@ -245,7 +235,14 @@ export const AllFriendsPanel = ({
     observer.observe(sentinel);
     loadMoreObserverRef.current = observer;
     return () => observer.disconnect();
-  }, [active, activeRelation, displayState, loadRelationUsers]);
+  }, [
+    active,
+    activeRelation,
+    displayLoading.loading,
+    displayLoading.loadingMore,
+    displayState.hasMore,
+    loadRelationUsers,
+  ]);
 
   const resetSelection = () => {
     onSelectionReset();
@@ -280,7 +277,7 @@ export const AllFriendsPanel = ({
       users={displayUsers}
       selectedMid={selectedMid}
       hasMore={displayState.hasMore}
-      loadingMore={displayState.loadingMore}
+      loadingMore={displayLoading.loadingMore}
       moreError={displayState.moreError}
       showFooter
       onRetry={() => loadRelationUsers(activeRelation)}
@@ -288,7 +285,7 @@ export const AllFriendsPanel = ({
     />
   );
   const renderListContent = () => {
-    if (displayState.loading) {
+    if (displayLoading.loading) {
       return <StateView text="正在读取用户列表..." />;
     }
     if (displayState.error) {

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -1,0 +1,354 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+
+import { getFollowers, getFollowings, searchFollowings } from "../../api.js";
+import { LIST_SCROLL_SELECTOR } from "../../constants.js";
+import { RelationFilter } from "../relation-filter/RelationFilter.jsx";
+import { SearchBox } from "../search-box/SearchBox.jsx";
+import { StateView } from "../state-view/StateView.jsx";
+import { UserList } from "../user-list/UserList.jsx";
+
+const createEmptyRelationState = () => ({
+  users: [],
+  page: 0,
+  hasMore: true,
+  loading: false,
+  loadingMore: false,
+  moreError: "",
+  error: "",
+  loaded: false,
+  search: {
+    users: [],
+    page: 0,
+    hasMore: true,
+    loading: false,
+    loadingMore: false,
+    moreError: "",
+    error: "",
+    loaded: false,
+    keyword: "",
+  },
+});
+
+const createRelationsState = () => ({
+  following: createEmptyRelationState(),
+  followers: createEmptyRelationState(),
+});
+
+const getRelationDisplayState = (relations, relation, searchTerm) => {
+  const relationState = relations[relation];
+  const keyword = searchTerm.trim();
+  if (relation === "following" && keyword) {
+    return relationState.search;
+  }
+  return relationState;
+};
+
+const getRelationDisplayUsers = (relations, relation, searchTerm) => {
+  const relationState = relations[relation];
+  const keyword = searchTerm.trim().toLowerCase();
+  if (!keyword) {
+    return relationState.users;
+  }
+  if (relation === "following") {
+    return relationState.search.users;
+  }
+  return relationState.users.filter((user) => user.name.toLowerCase().includes(keyword));
+};
+
+const updateRelationDisplayState = (relations, relation, useSearch, updater) => {
+  const relationState = relations[relation];
+  return {
+    ...relations,
+    [relation]: useSearch
+      ? {
+          ...relationState,
+          search: updater(relationState.search),
+        }
+      : updater(relationState),
+  };
+};
+
+export const AllFriendsPanel = ({
+  active,
+  mid,
+  selectedMid = null,
+  onSelect,
+  onSelectionReset = () => {},
+}) => {
+  const panelRef = useRef(null);
+  const stateRef = useRef(null);
+  const searchTimerRef = useRef(null);
+  const loadMoreObserverRef = useRef(null);
+  const loadingKeysRef = useRef(new Set());
+  const pendingScrollTopRef = useRef(null);
+  const searchComposingRef = useRef({ value: false });
+  const [activeRelation, setActiveRelation] = useState("following");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [relations, setRelations] = useState(createRelationsState);
+
+  stateRef.current = {
+    activeRelation,
+    searchTerm,
+    relations,
+    mid,
+  };
+
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(searchTimerRef.current);
+      loadMoreObserverRef.current?.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    setActiveRelation("following");
+    setSearchTerm("");
+    setRelations(createRelationsState());
+    onSelectionReset();
+  }, [mid, onSelectionReset]);
+
+  useLayoutEffect(() => {
+    const scrollTop = pendingScrollTopRef.current;
+    if (scrollTop === null) {
+      return;
+    }
+    pendingScrollTopRef.current = null;
+    const scrollRoot = panelRef.current?.querySelector(LIST_SCROLL_SELECTOR);
+    if (scrollRoot) {
+      scrollRoot.scrollTop = scrollTop;
+    }
+  }, [relations]);
+
+  const getListScrollTop = useCallback(
+    () => panelRef.current?.querySelector(LIST_SCROLL_SELECTOR)?.scrollTop ?? 0,
+    []
+  );
+
+  const setDisplayState = useCallback((relation, useSearch, updater) => {
+    setRelations((currentRelations) =>
+      updateRelationDisplayState(currentRelations, relation, useSearch, updater)
+    );
+  }, []);
+
+  const loadRelationUsers = useCallback(
+    async (relation, { reset = false, keywordOverride = null } = {}) => {
+      const current = stateRef.current;
+      const keyword = (keywordOverride ?? current.searchTerm).trim();
+      const useSearch = relation === "following" && Boolean(keyword);
+      const relationState = current.relations[relation];
+      const displayState = useSearch ? relationState.search : relationState;
+      const loadingKey = `${relation}:${useSearch ? keyword : "list"}`;
+
+      if (
+        !current.mid ||
+        loadingKeysRef.current.has(loadingKey) ||
+        displayState.loading ||
+        displayState.loadingMore ||
+        (!reset && displayState.loaded && !displayState.hasMore)
+      ) {
+        return;
+      }
+
+      const nextPage = reset ? 1 : displayState.page + 1;
+      const listScrollTop = !reset && displayState.loaded ? getListScrollTop() : null;
+      pendingScrollTopRef.current = listScrollTop;
+      loadingKeysRef.current.add(loadingKey);
+      setDisplayState(relation, useSearch, (state) => ({
+        ...state,
+        loading: reset || !state.loaded,
+        loadingMore: !(reset || !state.loaded),
+        error: "",
+        moreError: "",
+        keyword: useSearch ? keyword : state.keyword,
+      }));
+
+      try {
+        const loader = useSearch
+          ? searchFollowings
+          : relation === "following"
+            ? getFollowings
+            : getFollowers;
+        const nextResult = await loader({
+          mid: current.mid,
+          keyword,
+          page: nextPage,
+        });
+        setDisplayState(relation, useSearch, (state) => ({
+          ...state,
+          users: nextPage === 1 ? nextResult.users : [...state.users, ...nextResult.users],
+          page: nextPage,
+          hasMore: nextResult.hasMore,
+          loaded: true,
+        }));
+      } catch (loadError) {
+        setDisplayState(relation, useSearch, (state) => {
+          if (useSearch && nextPage === 1) {
+            return {
+              ...state,
+              users: relationState.users.filter((user) =>
+                user.name.toLowerCase().includes(keyword.toLowerCase())
+              ),
+              hasMore: false,
+              loaded: true,
+            };
+          }
+          if (nextPage === 1) {
+            return {
+              ...state,
+              error: loadError.message,
+            };
+          }
+          return {
+            ...state,
+            moreError: loadError.message,
+          };
+        });
+      } finally {
+        loadingKeysRef.current.delete(loadingKey);
+        setDisplayState(relation, useSearch, (state) => ({
+          ...state,
+          loading: false,
+          loadingMore: false,
+        }));
+      }
+    },
+    [getListScrollTop, setDisplayState]
+  );
+
+  useEffect(() => {
+    if (active) {
+      loadRelationUsers(activeRelation);
+    }
+  }, [active, activeRelation, loadRelationUsers]);
+
+  useEffect(() => {
+    loadMoreObserverRef.current?.disconnect();
+    loadMoreObserverRef.current = null;
+    if (!active) {
+      return;
+    }
+    const displayState = getRelationDisplayState(relations, activeRelation, searchTerm);
+    if (!displayState.hasMore || displayState.loading || displayState.loadingMore) {
+      return;
+    }
+    const scrollRoot = panelRef.current?.querySelector(LIST_SCROLL_SELECTOR);
+    const sentinel = scrollRoot?.querySelector("[data-bili-share-to-friends-list-sentinel]");
+    if (!scrollRoot || !sentinel) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          loadRelationUsers(activeRelation);
+        }
+      },
+      { root: scrollRoot, threshold: 0.1 }
+    );
+    observer.observe(sentinel);
+    loadMoreObserverRef.current = observer;
+    return () => observer.disconnect();
+  }, [active, activeRelation, loadRelationUsers, relations, searchTerm]);
+
+  const resetSelection = () => {
+    onSelectionReset();
+  };
+
+  const scheduleSearch = (value) => {
+    const previousKeyword = searchTerm.trim();
+    const nextKeyword = value.trim();
+    setSearchTerm(value);
+    if (previousKeyword === nextKeyword) {
+      return;
+    }
+    if (previousKeyword || nextKeyword) {
+      resetSelection();
+    }
+    window.clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = window.setTimeout(() => {
+      const current = stateRef.current;
+      if (current.activeRelation === "following" && nextKeyword) {
+        loadRelationUsers("following", { reset: true, keywordOverride: nextKeyword });
+      }
+    }, 300);
+  };
+
+  const renderUsers = ({
+    users,
+    emptyText,
+    hasMore = false,
+    loadingMore = false,
+    moreError = "",
+    onRetry = () => {},
+  }) => {
+    const userList = (
+      <UserList
+        users={users}
+        selectedMid={selectedMid}
+        hasMore={hasMore}
+        loadingMore={loadingMore}
+        moreError={moreError}
+        showFooter
+        onRetry={onRetry}
+        onSelect={onSelect}
+      />
+    );
+
+    if (users.length === 0) {
+      return (
+        <>
+          <StateView text={emptyText} />
+          {userList}
+        </>
+      );
+    }
+    return userList;
+  };
+
+  if (!active) {
+    return null;
+  }
+
+  const keyword = searchTerm.trim();
+  const displayState = getRelationDisplayState(relations, activeRelation, searchTerm);
+
+  return (
+    <div ref={panelRef}>
+      <RelationFilter
+        activeRelation={activeRelation}
+        onChange={(relation) => {
+          if (activeRelation === relation) {
+            return;
+          }
+          resetSelection();
+          setActiveRelation(relation);
+          loadRelationUsers(relation);
+        }}
+      />
+      <SearchBox
+        value={searchTerm}
+        notice={
+          activeRelation === "followers" && keyword
+            ? "粉丝搜索仅筛选已加载的用户，继续向下滚动可扩大搜索范围。"
+            : ""
+        }
+        composing={searchComposingRef.current}
+        onCompositionStart={() => window.clearTimeout(searchTimerRef.current)}
+        onInput={scheduleSearch}
+      />
+      {displayState.loading ? (
+        <StateView text="正在读取用户列表..." />
+      ) : displayState.error ? (
+        <StateView text={displayState.error} isError />
+      ) : (
+        renderUsers({
+          users: getRelationDisplayUsers(relations, activeRelation, searchTerm),
+          emptyText: activeRelation === "following" ? "暂无关注用户。" : "暂无粉丝用户。",
+          hasMore: displayState.hasMore,
+          loadingMore: displayState.loadingMore,
+          moreError: displayState.moreError,
+          onRetry: () => loadRelationUsers(activeRelation),
+        })
+      )}
+    </div>
+  );
+};

--- a/scripts/bilibili-share-to-friends/src/components/dialog-footer/DialogFooter.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/dialog-footer/DialogFooter.jsx
@@ -1,13 +1,49 @@
+import { useEffect, useState } from "preact/hooks";
+
+import { assertLogin, sendVideoText } from "../../api.js";
 import { SCRIPT_ID } from "../../constants.js";
 import "./style.css";
 
 export const DialogFooter = ({
-  sending = false,
-  canSend = false,
+  video,
+  selectedUser,
   showCloseOnly = false,
   onClose,
-  onSend = () => {},
+  onSendingChange = () => {},
+  onSendSuccess = () => {},
+  onSendError = () => {},
 }) => {
+  const [sending, setSending] = useState(false);
+
+  useEffect(() => {
+    onSendingChange(sending);
+  }, [onSendingChange, sending]);
+
+  const handleSend = async () => {
+    if (!selectedUser || sending) {
+      return;
+    }
+    setSending(true);
+    onSendError("");
+    try {
+      const login = await assertLogin();
+      await sendVideoText({
+        nav: login.nav,
+        csrf: login.csrf,
+        video,
+        receiver: selectedUser,
+      });
+      onSendSuccess({
+        message: `已将视频链接发送给 ${selectedUser.name}。`,
+        isError: false,
+      });
+    } catch (sendError) {
+      onSendError(sendError.message);
+    } finally {
+      setSending(false);
+    }
+  };
+
   if (showCloseOnly) {
     return (
       <div className={`${SCRIPT_ID}-footer`}>
@@ -30,8 +66,8 @@ export const DialogFooter = ({
       <button
         className={`${SCRIPT_ID}-btn ${SCRIPT_ID}-btn-primary`}
         type="button"
-        disabled={sending || !canSend}
-        onClick={onSend}
+        disabled={sending || !selectedUser}
+        onClick={handleSend}
       >
         {sending ? "发送中" : "发送"}
       </button>

--- a/scripts/bilibili-share-to-friends/src/components/index.js
+++ b/scripts/bilibili-share-to-friends/src/components/index.js
@@ -2,6 +2,7 @@ export * from "./dialog/Dialog.jsx";
 export * from "./dialog-footer/DialogFooter.jsx";
 export * from "./dialog-header/DialogHeader.jsx";
 export * from "./entry-button/EntryButton.jsx";
+export * from "./recent-recipients-panel/RecentRecipientsPanel.jsx";
 export * from "./recipient-tabs/RecipientTabs.jsx";
 export * from "./relation-filter/RelationFilter.jsx";
 export * from "./search-box/SearchBox.jsx";

--- a/scripts/bilibili-share-to-friends/src/components/index.js
+++ b/scripts/bilibili-share-to-friends/src/components/index.js
@@ -1,3 +1,4 @@
+export * from "./all-friends-panel/AllFriendsPanel.jsx";
 export * from "./dialog/Dialog.jsx";
 export * from "./dialog-footer/DialogFooter.jsx";
 export * from "./dialog-header/DialogHeader.jsx";

--- a/scripts/bilibili-share-to-friends/src/components/recent-recipients-panel/RecentRecipientsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/recent-recipients-panel/RecentRecipientsPanel.jsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "preact/hooks";
+
+import { getRecentSessions } from "../../api.js";
+import { StateView } from "../state-view/StateView.jsx";
+import { UserList } from "../user-list/UserList.jsx";
+
+export const RecentRecipientsPanel = ({ active, selectedMid = null, onSelect }) => {
+  const [recent, setRecent] = useState({
+    users: [],
+    error: "",
+    loading: false,
+    loaded: false,
+  });
+
+  useEffect(() => {
+    if (!active || recent.loaded || recent.loading) {
+      return;
+    }
+
+    let canceled = false;
+    setRecent((state) => ({
+      ...state,
+      loading: true,
+      error: "",
+    }));
+
+    getRecentSessions()
+      .then((users) => {
+        if (canceled) {
+          return;
+        }
+        setRecent({
+          users,
+          error: "",
+          loading: false,
+          loaded: true,
+        });
+      })
+      .catch((error) => {
+        if (canceled) {
+          return;
+        }
+        setRecent({
+          users: [],
+          error: error.message,
+          loading: false,
+          loaded: true,
+        });
+      });
+
+    return () => {
+      canceled = true;
+    };
+  }, [active, recent.loaded, recent.loading]);
+
+  if (!active) {
+    return null;
+  }
+  if (recent.loading) {
+    return <StateView text="正在读取最近私信联系人..." />;
+  }
+  if (recent.error) {
+    return <StateView text={recent.error} isError />;
+  }
+  if (recent.users.length === 0) {
+    return <StateView text="暂无最近私信联系人。" />;
+  }
+  return <UserList users={recent.users} selectedMid={selectedMid} onSelect={onSelect} />;
+};

--- a/scripts/bilibili-share-to-friends/src/ui.jsx
+++ b/scripts/bilibili-share-to-friends/src/ui.jsx
@@ -7,6 +7,7 @@ import {
   createEntryButton as createShareEntryButton,
   DialogFooter,
   DialogHeader,
+  RecentRecipientsPanel,
   RecipientTabs,
   RelationFilter,
   SearchBox,
@@ -18,7 +19,6 @@ import {
   assertLogin,
   getFollowers,
   getFollowings,
-  getRecentSessions,
   getVideoInfo,
   searchFollowings,
   sendVideoText,
@@ -86,14 +86,7 @@ const updateRelationDisplayState = (relations, relation, useSearch, updater) => 
   };
 };
 
-export const ShareDialog = ({
-  dialog,
-  video,
-  nav = null,
-  sessions = [],
-  status = "",
-  error = "",
-}) => {
+export const ShareDialog = ({ dialog, video, nav = null, status = "", error = "" }) => {
   const bodyRef = useRef(null);
   const stateRef = useRef(null);
   const searchTimerRef = useRef(null);
@@ -105,12 +98,6 @@ export const ShareDialog = ({
   const [activeRelation, setActiveRelation] = useState("following");
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedUser, setSelectedUser] = useState(null);
-  const [recent, setRecent] = useState({
-    users: sessions,
-    error: "",
-    loading: false,
-    loaded: sessions.length > 0,
-  });
   const [relations, setRelations] = useState(createRelationsState);
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState("");
@@ -125,16 +112,10 @@ export const ShareDialog = ({
   };
 
   useEffect(() => {
-    setRecent({
-      users: sessions,
-      error: "",
-      loading: false,
-      loaded: sessions.length > 0,
-    });
     setSelectedUser(null);
     setSendError("");
     setResult(null);
-  }, [sessions]);
+  }, [video]);
 
   useEffect(() => {
     return () => {
@@ -440,12 +421,15 @@ export const ShareDialog = ({
             }
           }}
         />
-        {activeTab === "recent"
-          ? renderUsers({
-              users: recent.users,
-              emptyText: "暂无最近私信联系人。",
-            })
-          : renderRelationContent()}
+        <RecentRecipientsPanel
+          active={activeTab === "recent"}
+          selectedMid={selectedUser?.mid}
+          onSelect={(_button, user) => {
+            setSendError("");
+            setSelectedUser(user);
+          }}
+        />
+        {activeTab === "all" ? renderRelationContent() : null}
       </>
     );
   };
@@ -468,16 +452,9 @@ export const ShareDialog = ({
   );
 };
 
-const renderDialog = ({ dialog, video, nav = null, sessions = [], status = "", error = "" }) => {
+const renderDialog = ({ dialog, video, nav = null, status = "", error = "" }) => {
   render(
-    <ShareDialog
-      dialog={dialog}
-      video={video}
-      nav={nav}
-      sessions={sessions}
-      status={status}
-      error={error}
-    />,
+    <ShareDialog dialog={dialog} video={video} nav={nav} status={status} error={error} />,
     dialog
   );
 };
@@ -492,7 +469,7 @@ const openShareDialog = async () => {
   renderDialog({
     dialog,
     video: fallbackVideo,
-    status: "正在读取视频和最近私信联系人...",
+    status: "正在读取视频信息...",
   });
   if (!dialog.open) {
     dialog.showModal();
@@ -501,11 +478,10 @@ const openShareDialog = async () => {
   try {
     const { nav } = await assertLogin();
     const video = await getVideoInfo();
-    const sessions = await getRecentSessions();
     if (!dialog.isConnected || !dialog.open) {
       return;
     }
-    renderDialog({ dialog, video, nav, sessions });
+    renderDialog({ dialog, video, nav });
   } catch (error) {
     if (!dialog.isConnected || !dialog.open) {
       return;

--- a/scripts/bilibili-share-to-friends/src/ui.jsx
+++ b/scripts/bilibili-share-to-friends/src/ui.jsx
@@ -21,22 +21,45 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
   const [selectedUser, setSelectedUser] = useState(null);
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState("");
-  const [result, setResult] = useState(null);
+  const [sendResult, setSendResult] = useState(null);
 
   useEffect(() => {
     setSelectedUser(null);
     setSendError("");
-    setResult(null);
+    setSendResult(null);
   }, [video]);
+
+  const handleClose = useCallback(() => closeDialog(dialog), [dialog]);
 
   const resetSelection = useCallback(() => {
     setSelectedUser(null);
     setSendError("");
   }, []);
 
+  const handleTabChange = useCallback(
+    (tab) => {
+      if (activeTab === tab) {
+        return;
+      }
+      resetSelection();
+      setActiveTab(tab);
+    },
+    [activeTab, resetSelection]
+  );
+
+  const handleUserSelect = useCallback((_button, user) => {
+    setSendError("");
+    setSelectedUser(user);
+  }, []);
+
+  const handleSendSuccess = useCallback((nextResult) => {
+    setSendError("");
+    setSendResult(nextResult);
+  }, []);
+
   const renderBody = () => {
-    if (result) {
-      return <StateView text={result.message} isError={result.isError} />;
+    if (sendResult) {
+      return <StateView text={sendResult.message} isError={sendResult.isError} />;
     }
     if (status) {
       return <StateView text={status} />;
@@ -47,33 +70,18 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
     return (
       <>
         {sendError ? <StateView text={sendError} isError /> : null}
-        <RecipientTabs
-          activeTab={activeTab}
-          onChange={(tab) => {
-            if (activeTab === tab) {
-              return;
-            }
-            resetSelection();
-            setActiveTab(tab);
-          }}
-        />
+        <RecipientTabs activeTab={activeTab} onChange={handleTabChange} />
         <RecentRecipientsPanel
           active={activeTab === "recent"}
           selectedMid={selectedUser?.mid}
-          onSelect={(_button, user) => {
-            setSendError("");
-            setSelectedUser(user);
-          }}
+          onSelect={handleUserSelect}
         />
         <AllFriendsPanel
           active={activeTab === "all"}
           mid={nav?.mid}
           selectedMid={selectedUser?.mid}
           onSelectionReset={resetSelection}
-          onSelect={(_button, user) => {
-            setSendError("");
-            setSelectedUser(user);
-          }}
+          onSelect={handleUserSelect}
         />
       </>
     );
@@ -81,16 +89,16 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
 
   return (
     <div className={`${SCRIPT_ID}-dialog-content`}>
-      <DialogHeader title="分享给 B站好友" disabled={sending} onClose={() => closeDialog(dialog)} />
+      <DialogHeader title="分享给 B站好友" disabled={sending} onClose={handleClose} />
       <VideoPreview video={video} />
       <div className={`${SCRIPT_ID}-body`}>{renderBody()}</div>
       <DialogFooter
         video={video}
         selectedUser={selectedUser}
-        showCloseOnly={Boolean(result)}
-        onClose={() => closeDialog(dialog)}
+        showCloseOnly={Boolean(sendResult)}
+        onClose={handleClose}
         onSendingChange={setSending}
-        onSendSuccess={setResult}
+        onSendSuccess={handleSendSuccess}
         onSendError={setSendError}
       />
     </div>

--- a/scripts/bilibili-share-to-friends/src/ui.jsx
+++ b/scripts/bilibili-share-to-friends/src/ui.jsx
@@ -13,7 +13,7 @@ import {
   StateView,
   VideoPreview,
 } from "./components/index.js";
-import { assertLogin, getVideoInfo, sendVideoText } from "./api.js";
+import { assertLogin, getVideoInfo } from "./api.js";
 import { SCRIPT_ID } from "./constants.js";
 
 export const ShareDialog = ({ dialog, video, nav = null, status = "", error = "" }) => {
@@ -33,31 +33,6 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
     setSelectedUser(null);
     setSendError("");
   }, []);
-
-  const handleSend = async () => {
-    if (!selectedUser || sending) {
-      return;
-    }
-    setSending(true);
-    setSendError("");
-    try {
-      const login = await assertLogin();
-      await sendVideoText({
-        nav: login.nav,
-        csrf: login.csrf,
-        video,
-        receiver: selectedUser,
-      });
-      setResult({
-        message: `已将视频链接发送给 ${selectedUser.name}。`,
-        isError: false,
-      });
-    } catch (sendErrorResult) {
-      setSendError(sendErrorResult.message);
-    } finally {
-      setSending(false);
-    }
-  };
 
   const renderBody = () => {
     if (result) {
@@ -110,11 +85,13 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
       <VideoPreview video={video} />
       <div className={`${SCRIPT_ID}-body`}>{renderBody()}</div>
       <DialogFooter
+        video={video}
+        selectedUser={selectedUser}
         showCloseOnly={Boolean(result)}
-        sending={sending}
-        canSend={Boolean(selectedUser)}
         onClose={() => closeDialog(dialog)}
-        onSend={handleSend}
+        onSendingChange={setSending}
+        onSendSuccess={setResult}
+        onSendError={setSendError}
       />
     </div>
   );

--- a/scripts/bilibili-share-to-friends/src/ui.jsx
+++ b/scripts/bilibili-share-to-friends/src/ui.jsx
@@ -1,7 +1,8 @@
 import { render } from "preact";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useState } from "preact/hooks";
 
 import {
+  AllFriendsPanel,
   closeDialog,
   createDialog,
   createEntryButton as createShareEntryButton,
@@ -9,107 +10,18 @@ import {
   DialogHeader,
   RecentRecipientsPanel,
   RecipientTabs,
-  RelationFilter,
-  SearchBox,
   StateView,
-  UserList,
   VideoPreview,
 } from "./components/index.js";
-import {
-  assertLogin,
-  getFollowers,
-  getFollowings,
-  getVideoInfo,
-  searchFollowings,
-  sendVideoText,
-} from "./api.js";
-import { LIST_SCROLL_SELECTOR, SCRIPT_ID } from "./constants.js";
-
-const createEmptyRelationState = () => ({
-  users: [],
-  page: 0,
-  hasMore: true,
-  loading: false,
-  loadingMore: false,
-  moreError: "",
-  error: "",
-  loaded: false,
-  search: {
-    users: [],
-    page: 0,
-    hasMore: true,
-    loading: false,
-    loadingMore: false,
-    moreError: "",
-    error: "",
-    loaded: false,
-    keyword: "",
-  },
-});
-
-const createRelationsState = () => ({
-  following: createEmptyRelationState(),
-  followers: createEmptyRelationState(),
-});
-
-const getRelationDisplayState = (relations, relation, searchTerm) => {
-  const relationState = relations[relation];
-  const keyword = searchTerm.trim();
-  if (relation === "following" && keyword) {
-    return relationState.search;
-  }
-  return relationState;
-};
-
-const getRelationDisplayUsers = (relations, relation, searchTerm) => {
-  const relationState = relations[relation];
-  const keyword = searchTerm.trim().toLowerCase();
-  if (!keyword) {
-    return relationState.users;
-  }
-  if (relation === "following") {
-    return relationState.search.users;
-  }
-  return relationState.users.filter((user) => user.name.toLowerCase().includes(keyword));
-};
-
-const updateRelationDisplayState = (relations, relation, useSearch, updater) => {
-  const relationState = relations[relation];
-  return {
-    ...relations,
-    [relation]: useSearch
-      ? {
-          ...relationState,
-          search: updater(relationState.search),
-        }
-      : updater(relationState),
-  };
-};
+import { assertLogin, getVideoInfo, sendVideoText } from "./api.js";
+import { SCRIPT_ID } from "./constants.js";
 
 export const ShareDialog = ({ dialog, video, nav = null, status = "", error = "" }) => {
-  const bodyRef = useRef(null);
-  const stateRef = useRef(null);
-  const searchTimerRef = useRef(null);
-  const loadMoreObserverRef = useRef(null);
-  const loadingKeysRef = useRef(new Set());
-  const pendingScrollTopRef = useRef(null);
-  const searchComposingRef = useRef({ value: false });
   const [activeTab, setActiveTab] = useState("recent");
-  const [activeRelation, setActiveRelation] = useState("following");
-  const [searchTerm, setSearchTerm] = useState("");
   const [selectedUser, setSelectedUser] = useState(null);
-  const [relations, setRelations] = useState(createRelationsState);
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState("");
   const [result, setResult] = useState(null);
-
-  stateRef.current = {
-    activeTab,
-    activeRelation,
-    searchTerm,
-    relations,
-    nav,
-  };
 
   useEffect(() => {
     setSelectedUser(null);
@@ -117,175 +29,10 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
     setResult(null);
   }, [video]);
 
-  useEffect(() => {
-    return () => {
-      window.clearTimeout(searchTimerRef.current);
-      loadMoreObserverRef.current?.disconnect();
-    };
-  }, []);
-
-  useLayoutEffect(() => {
-    const scrollTop = pendingScrollTopRef.current;
-    if (scrollTop === null) {
-      return;
-    }
-    pendingScrollTopRef.current = null;
-    const scrollRoot = bodyRef.current?.querySelector(LIST_SCROLL_SELECTOR);
-    if (scrollRoot) {
-      scrollRoot.scrollTop = scrollTop;
-    }
-  }, [relations]);
-
-  const resetSelection = () => {
+  const resetSelection = useCallback(() => {
     setSelectedUser(null);
     setSendError("");
-  };
-
-  const getListScrollTop = useCallback(
-    () => bodyRef.current?.querySelector(LIST_SCROLL_SELECTOR)?.scrollTop ?? 0,
-    []
-  );
-
-  const setDisplayState = useCallback((relation, useSearch, updater) => {
-    setRelations((currentRelations) =>
-      updateRelationDisplayState(currentRelations, relation, useSearch, updater)
-    );
   }, []);
-
-  const loadRelationUsers = useCallback(
-    async (relation, { reset = false, keywordOverride = null } = {}) => {
-      const current = stateRef.current;
-      const keyword = (keywordOverride ?? current.searchTerm).trim();
-      const useSearch = relation === "following" && Boolean(keyword);
-      const relationState = current.relations[relation];
-      const displayState = useSearch ? relationState.search : relationState;
-      const loadingKey = `${relation}:${useSearch ? keyword : "list"}`;
-
-      if (
-        !current.nav ||
-        loadingKeysRef.current.has(loadingKey) ||
-        displayState.loading ||
-        displayState.loadingMore ||
-        (!reset && displayState.loaded && !displayState.hasMore)
-      ) {
-        return;
-      }
-
-      const nextPage = reset ? 1 : displayState.page + 1;
-      const listScrollTop = !reset && displayState.loaded ? getListScrollTop() : null;
-      pendingScrollTopRef.current = listScrollTop;
-      loadingKeysRef.current.add(loadingKey);
-      setDisplayState(relation, useSearch, (state) => ({
-        ...state,
-        loading: reset || !state.loaded,
-        loadingMore: !(reset || !state.loaded),
-        error: "",
-        moreError: "",
-        keyword: useSearch ? keyword : state.keyword,
-      }));
-
-      try {
-        const loader = useSearch
-          ? searchFollowings
-          : relation === "following"
-            ? getFollowings
-            : getFollowers;
-        const nextResult = await loader({
-          mid: current.nav.mid,
-          keyword,
-          page: nextPage,
-        });
-        setDisplayState(relation, useSearch, (state) => ({
-          ...state,
-          users: nextPage === 1 ? nextResult.users : [...state.users, ...nextResult.users],
-          page: nextPage,
-          hasMore: nextResult.hasMore,
-          loaded: true,
-        }));
-      } catch (loadError) {
-        setDisplayState(relation, useSearch, (state) => {
-          if (useSearch && nextPage === 1) {
-            return {
-              ...state,
-              users: relationState.users.filter((user) =>
-                user.name.toLowerCase().includes(keyword.toLowerCase())
-              ),
-              hasMore: false,
-              loaded: true,
-            };
-          }
-          if (nextPage === 1) {
-            return {
-              ...state,
-              error: loadError.message,
-            };
-          }
-          return {
-            ...state,
-            moreError: loadError.message,
-          };
-        });
-      } finally {
-        loadingKeysRef.current.delete(loadingKey);
-        setDisplayState(relation, useSearch, (state) => ({
-          ...state,
-          loading: false,
-          loadingMore: false,
-        }));
-      }
-    },
-    [getListScrollTop, setDisplayState]
-  );
-
-  useEffect(() => {
-    loadMoreObserverRef.current?.disconnect();
-    loadMoreObserverRef.current = null;
-    if (activeTab !== "all") {
-      return;
-    }
-    const displayState = getRelationDisplayState(relations, activeRelation, searchTerm);
-    if (!displayState.hasMore || displayState.loading || displayState.loadingMore) {
-      return;
-    }
-    const scrollRoot = bodyRef.current?.querySelector(LIST_SCROLL_SELECTOR);
-    const sentinel = scrollRoot?.querySelector("[data-bili-share-to-friends-list-sentinel]");
-    if (!scrollRoot || !sentinel) {
-      return;
-    }
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          loadRelationUsers(activeRelation);
-        }
-      },
-      { root: scrollRoot, threshold: 0.1 }
-    );
-    observer.observe(sentinel);
-    loadMoreObserverRef.current = observer;
-    return () => observer.disconnect();
-  }, [activeRelation, activeTab, loadRelationUsers, relations, searchTerm]);
-
-  const scheduleSearch = (value) => {
-    const previousKeyword = searchTerm.trim();
-    const nextKeyword = value.trim();
-    setSearchTerm(value);
-    if (previousKeyword === nextKeyword) {
-      return;
-    }
-    if (previousKeyword || nextKeyword) {
-      resetSelection();
-    }
-    window.clearTimeout(searchTimerRef.current);
-    searchTimerRef.current = window.setTimeout(() => {
-      const current = stateRef.current;
-      if (current.activeTab !== "all") {
-        return;
-      }
-      if (current.activeRelation === "following" && nextKeyword) {
-        loadRelationUsers("following", { reset: true, keywordOverride: nextKeyword });
-      }
-    }, 300);
-  };
 
   const handleSend = async () => {
     if (!selectedUser || sending) {
@@ -312,89 +59,6 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
     }
   };
 
-  const renderUsers = ({
-    users,
-    emptyText,
-    hasMore = false,
-    loadingMore = false,
-    moreError = "",
-    showFooter = false,
-    onRetry = () => {},
-  }) => {
-    const userList = (
-      <UserList
-        users={users}
-        selectedMid={selectedUser?.mid}
-        hasMore={hasMore}
-        loadingMore={loadingMore}
-        moreError={moreError}
-        showFooter={showFooter}
-        onRetry={onRetry}
-        onSelect={(_button, user) => {
-          setSendError("");
-          setSelectedUser(user);
-        }}
-      />
-    );
-
-    if (users.length === 0) {
-      return (
-        <>
-          <StateView text={emptyText} />
-          {showFooter ? userList : null}
-        </>
-      );
-    }
-    return userList;
-  };
-
-  const renderRelationContent = () => {
-    const keyword = searchTerm.trim();
-    const displayState = getRelationDisplayState(relations, activeRelation, searchTerm);
-
-    return (
-      <>
-        <RelationFilter
-          activeRelation={activeRelation}
-          onChange={(relation) => {
-            if (activeRelation === relation) {
-              return;
-            }
-            resetSelection();
-            setActiveRelation(relation);
-            loadRelationUsers(relation);
-          }}
-        />
-        <SearchBox
-          value={searchTerm}
-          notice={
-            activeRelation === "followers" && keyword
-              ? "粉丝搜索仅筛选已加载的用户，继续向下滚动可扩大搜索范围。"
-              : ""
-          }
-          composing={searchComposingRef.current}
-          onCompositionStart={() => window.clearTimeout(searchTimerRef.current)}
-          onInput={scheduleSearch}
-        />
-        {displayState.loading ? (
-          <StateView text="正在读取用户列表..." />
-        ) : displayState.error ? (
-          <StateView text={displayState.error} isError />
-        ) : (
-          renderUsers({
-            users: getRelationDisplayUsers(relations, activeRelation, searchTerm),
-            emptyText: activeRelation === "following" ? "暂无关注用户。" : "暂无粉丝用户。",
-            hasMore: displayState.hasMore,
-            loadingMore: displayState.loadingMore,
-            moreError: displayState.moreError,
-            showFooter: true,
-            onRetry: () => loadRelationUsers(activeRelation),
-          })
-        )}
-      </>
-    );
-  };
-
   const renderBody = () => {
     if (result) {
       return <StateView text={result.message} isError={result.isError} />;
@@ -416,9 +80,6 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
             }
             resetSelection();
             setActiveTab(tab);
-            if (tab === "all") {
-              loadRelationUsers(activeRelation);
-            }
           }}
         />
         <RecentRecipientsPanel
@@ -429,7 +90,16 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
             setSelectedUser(user);
           }}
         />
-        {activeTab === "all" ? renderRelationContent() : null}
+        <AllFriendsPanel
+          active={activeTab === "all"}
+          mid={nav?.mid}
+          selectedMid={selectedUser?.mid}
+          onSelectionReset={resetSelection}
+          onSelect={(_button, user) => {
+            setSendError("");
+            setSelectedUser(user);
+          }}
+        />
       </>
     );
   };
@@ -438,9 +108,7 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
     <div className={`${SCRIPT_ID}-dialog-content`}>
       <DialogHeader title="分享给 B站好友" disabled={sending} onClose={() => closeDialog(dialog)} />
       <VideoPreview video={video} />
-      <div className={`${SCRIPT_ID}-body`} ref={bodyRef}>
-        {renderBody()}
-      </div>
+      <div className={`${SCRIPT_ID}-body`}>{renderBody()}</div>
       <DialogFooter
         showCloseOnly={Boolean(result)}
         sending={sending}


### PR DESCRIPTION
## Summary

- 将最近聊天面板拆为 `RecentRecipientsPanel`，由面板内部维护最近会话加载、错误、空态和列表状态。
- 将全部好友面板拆为 `AllFriendsPanel`，由面板内部维护关注/粉丝切换、搜索、IME 保护、300ms debounce、分页、滚动加载、重试和滚动位置恢复。
- 简化 `AllFriendsPanel` 的关系状态结构：拆出 `followingSearch`，并由 `loadingPage` 推导 `loading` / `loadingMore`。
- 将发送请求和发送中状态下沉到 `DialogFooter`，父级只通过回调接收发送中、成功和失败结果。
- 精简 `ui.jsx`，保留弹窗生命周期、tab、选中用户、全局状态/错误和发送结果等跨组件共享状态。
- 将通用 `debounce` 放入 `@tampermonkey-scripts/shared`，并在好友搜索中复用。
- 视频信息仍由父级加载并共享给 `VideoPreview` 和 `DialogFooter`，视频读取失败保持全局错误态。

## Verification

- `pnpm build:bilibili`
- `pnpm lint`
- `pnpm -r test`

## Notes

- 该 PR 基于已合并的 #25 创建，只包含弹窗状态下沉和相关 review fix。
- `dist/` 产物未提交。