### PR TITLE
fix: bilibili-share-to-friends 修复中文输入搜索

### DIFF
--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -41,8 +41,6 @@ export const AllFriendsPanel = ({
   const loadMoreObserverRef = useRef(null);
   const loadingKeysRef = useRef(new Set());
   const pendingScrollTopRef = useRef(null);
-  const searchComposingRef = useRef({ value: false });
-  const debouncedSearchRef = useRef(null);
   const [activeRelation, setActiveRelation] = useState("following");
   const [searchTerm, setSearchTerm] = useState("");
   const [relations, setRelations] = useState(createRelationsState);
@@ -78,13 +76,6 @@ export const AllFriendsPanel = ({
     followingSearch,
     mid,
   };
-
-  useEffect(() => {
-    return () => {
-      debouncedSearchRef.current?.cancel();
-      loadMoreObserverRef.current?.disconnect();
-    };
-  }, []);
 
   useEffect(() => {
     setActiveRelation("following");
@@ -206,14 +197,24 @@ export const AllFriendsPanel = ({
     [getListScrollTop, setPageState]
   );
 
-  if (!debouncedSearchRef.current) {
-    debouncedSearchRef.current = debounce((nextKeyword) => {
-      const current = stateRef.current;
-      if (current.activeRelation === "following" && nextKeyword) {
-        loadRelationUsers("following", { reset: true, keywordOverride: nextKeyword });
-      }
-    }, 300);
-  }
+  const debouncedSearch = useMemo(
+    () =>
+      debounce((nextKeyword) => {
+        const current = stateRef.current;
+        if (current.activeRelation === "following" && nextKeyword) {
+          loadRelationUsers("following", { reset: true, keywordOverride: nextKeyword });
+        }
+      }, 300),
+    [loadRelationUsers]
+  );
+
+  useEffect(() => {
+    return () => loadMoreObserverRef.current?.disconnect();
+  }, []);
+
+  useEffect(() => {
+    return () => debouncedSearch.cancel();
+  }, [debouncedSearch]);
 
   useEffect(() => {
     if (active) {
@@ -259,7 +260,7 @@ export const AllFriendsPanel = ({
     onSelectionReset();
   };
 
-  const scheduleSearch = (value) => {
+  const scheduleSearch = (value, { immediate = false } = {}) => {
     const previousKeyword = searchTerm.trim();
     const nextKeyword = value.trim();
     setSearchTerm(value);
@@ -269,7 +270,15 @@ export const AllFriendsPanel = ({
     if (previousKeyword || nextKeyword) {
       resetSelection();
     }
-    debouncedSearchRef.current(nextKeyword);
+    if (immediate) {
+      debouncedSearch.cancel();
+      const current = stateRef.current;
+      if (current.activeRelation === "following" && nextKeyword) {
+        loadRelationUsers("following", { reset: true, keywordOverride: nextKeyword });
+      }
+      return;
+    }
+    debouncedSearch(nextKeyword);
   };
 
   if (!active) {
@@ -321,8 +330,7 @@ export const AllFriendsPanel = ({
             ? "粉丝搜索仅筛选已加载的用户，继续向下滚动可扩大搜索范围。"
             : ""
         }
-        composing={searchComposingRef.current}
-        onCompositionStart={() => debouncedSearchRef.current?.cancel()}
+        onCompositionStart={() => debouncedSearch.cancel()}
         onInput={scheduleSearch}
       />
       {renderListContent()}

--- a/scripts/bilibili-share-to-friends/src/components/search-box/SearchBox.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/search-box/SearchBox.jsx
@@ -1,3 +1,5 @@
+import { useEffect, useLayoutEffect, useRef } from "preact/hooks";
+
 import { SCRIPT_ID } from "../../constants.js";
 import "./style.css";
 
@@ -7,29 +9,118 @@ export const SearchBox = ({
   notice = "",
   onCompositionStart = () => {},
   onInput,
-  composing = { value: false },
 }) => {
+  const inputRef = useRef(null);
+  const composingRef = useRef(false);
+  const lastCommittedValueRef = useRef(value ?? "");
+  const latestCallbacksRef = useRef({ onCompositionStart, onInput });
+
+  latestCallbacksRef.current = { onCompositionStart, onInput };
+
+  useLayoutEffect(() => {
+    if (composingRef.current) {
+      return;
+    }
+    const nextValue = value ?? "";
+    if (inputRef.current && inputRef.current.value !== nextValue) {
+      inputRef.current.value = nextValue;
+      lastCommittedValueRef.current = nextValue;
+    }
+  }, [value]);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) {
+      return () => {};
+    }
+
+    let compositionCommitTimer = null;
+
+    const clearCompositionCommit = () => {
+      window.clearTimeout(compositionCommitTimer);
+      compositionCommitTimer = null;
+    };
+
+    const commitValue = (nextValue, options) => {
+      if (lastCommittedValueRef.current === nextValue) {
+        return;
+      }
+      lastCommittedValueRef.current = nextValue;
+      latestCallbacksRef.current.onInput(nextValue, options);
+    };
+
+    const commitCurrentValue = (options) => {
+      clearCompositionCommit();
+      commitValue(input.value, options);
+    };
+
+    const scheduleCompositionCommit = () => {
+      clearCompositionCommit();
+      compositionCommitTimer = window.setTimeout(() => {
+        commitCurrentValue({ immediate: true });
+      }, 0);
+    };
+
+    // 在油猴脚本环境中，Preact composition 事件可能拿不到 IME 提交后的最终值。
+    // 这里改用原生事件，并直接读取 DOM value。
+    const handleCompositionStart = () => {
+      clearCompositionCommit();
+      composingRef.current = true;
+      latestCallbacksRef.current.onCompositionStart();
+    };
+
+    const handleCompositionEnd = () => {
+      composingRef.current = false;
+      // 等浏览器先提交组合输入文本，再通知父级搜索逻辑。
+      scheduleCompositionCommit();
+    };
+
+    const handleInput = (event) => {
+      if (composingRef.current || event.isComposing) {
+        return;
+      }
+      if (compositionCommitTimer) {
+        return;
+      }
+      commitCurrentValue();
+    };
+
+    const handleChange = () => {
+      if (!composingRef.current) {
+        commitCurrentValue();
+      }
+    };
+
+    const handleKeyUp = (event) => {
+      if (!composingRef.current && !event.isComposing) {
+        commitCurrentValue({ immediate: true });
+      }
+    };
+
+    input.addEventListener("compositionstart", handleCompositionStart);
+    input.addEventListener("compositionend", handleCompositionEnd);
+    input.addEventListener("input", handleInput);
+    input.addEventListener("change", handleChange);
+    input.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      clearCompositionCommit();
+      input.removeEventListener("compositionstart", handleCompositionStart);
+      input.removeEventListener("compositionend", handleCompositionEnd);
+      input.removeEventListener("input", handleInput);
+      input.removeEventListener("change", handleChange);
+      input.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
   return (
     <div className={`${SCRIPT_ID}-search`}>
       <input
+        ref={inputRef}
         className={`${SCRIPT_ID}-search-input`}
         type="search"
-        value={value}
+        defaultValue={value}
         placeholder={placeholder}
-        onCompositionStart={() => {
-          composing.value = true;
-          onCompositionStart();
-        }}
-        onCompositionEnd={(event) => {
-          composing.value = false;
-          onInput(event.currentTarget.value);
-        }}
-        onInput={(event) => {
-          if (composing.value || event.isComposing) {
-            return;
-          }
-          onInput(event.currentTarget.value);
-        }}
       />
       {notice ? <div className={`${SCRIPT_ID}-search-notice`}>{notice}</div> : null}
     </div>


### PR DESCRIPTION
## Summary
- 修复 bilibili 分享弹窗【全部好友】面板中中文输入法提交后不触发搜索的问题。
- 搜索框改为 DOM 值优先的半非受控输入，并用原生 IME/input 事件读取最终输入值。
- 将中文 IME 提交后的搜索改为 immediate 执行，普通输入仍保留 300ms debounce。

## Root Cause
在油猴脚本运行环境中，受控 input、Preact composition 合成事件和中文 IME 的事件时序组合不稳定，`onCompositionEnd` 链路可能拿不到提交后的最终中文值，导致父级搜索逻辑没有收到有效关键字更新。

## Validation
- `pnpm build:bilibili`
- `pnpm lint`
- `pnpm -r test`
- 手工验证：中文输入法在【全部好友】搜索中已能正常触发搜索。