### PR TITLE
feat: bilibili-share-to-friends 支持昵称跳转用户主页并统一关系筛选样式

### DIFF
--- a/scripts/bilibili-share-to-friends/src/components/relation-filter/style.css
+++ b/scripts/bilibili-share-to-friends/src/components/relation-filter/style.css
@@ -15,8 +15,23 @@
 }
 
 .bili-share-to-friends-relation-option input {
-  width: 14px;
-  height: 14px;
+  appearance: none;
+  box-sizing: border-box;
+  width: 15px;
+  height: 15px;
   margin: 0;
-  accent-color: #00aeec;
+  border: 1px solid #c9ccd0;
+  border-radius: 50%;
+  background: #fff;
+  cursor: pointer;
+}
+
+.bili-share-to-friends-relation-option input:checked {
+  border-color: #00aeec;
+  background: radial-gradient(circle at center, #00aeec 0 43%, transparent 45%);
+}
+
+.bili-share-to-friends-relation-option input:focus-visible {
+  outline: 2px solid rgba(0, 174, 236, 0.2);
+  outline-offset: 2px;
 }

--- a/scripts/bilibili-share-to-friends/src/components/user-list-item/UserListItem.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/user-list-item/UserListItem.jsx
@@ -1,30 +1,61 @@
 import { SCRIPT_ID } from "../../constants.js";
 import "./style.css";
 
-export const UserListItem = ({ user, selected = false, onSelect }) => (
-  <button
-    className={`${SCRIPT_ID}-person`}
-    type="button"
-    aria-selected={String(selected)}
-    onClick={(event) => onSelect(event.currentTarget, user)}
-  >
-    <img
-      className={`${SCRIPT_ID}-avatar`}
-      src={user.avatar}
-      alt=""
-      referrerPolicy="no-referrer"
-      onError={(event) => {
-        if (event.currentTarget.dataset.fallbackApplied === "true") {
-          return;
-        }
-        event.currentTarget.dataset.fallbackApplied = "true";
-        event.currentTarget.src = "https://static.hdslb.com/images/member/noface.gif";
-      }}
-    />
-    <div>
-      <div className={`${SCRIPT_ID}-name`}>{user.name}</div>
-      <div className={`${SCRIPT_ID}-meta`}>{user.meta || `UID ${user.mid}`}</div>
+const isLinkTarget = (target) => target instanceof Element && Boolean(target.closest("a"));
+
+export const UserListItem = ({ user, selected = false, onSelect }) => {
+  const handleSelect = (event) => {
+    if (isLinkTarget(event.target)) {
+      return;
+    }
+
+    onSelect(event.currentTarget, user);
+  };
+
+  const handleKeyDown = (event) => {
+    if (isLinkTarget(event.target) || (event.key !== "Enter" && event.key !== " ")) {
+      return;
+    }
+
+    event.preventDefault();
+    onSelect(event.currentTarget, user);
+  };
+
+  return (
+    <div
+      className={`${SCRIPT_ID}-person`}
+      role="button"
+      tabIndex={0}
+      aria-selected={String(selected)}
+      onClick={handleSelect}
+      onKeyDown={handleKeyDown}
+    >
+      <img
+        className={`${SCRIPT_ID}-avatar`}
+        src={user.avatar}
+        alt=""
+        referrerPolicy="no-referrer"
+        onError={(event) => {
+          if (event.currentTarget.dataset.fallbackApplied === "true") {
+            return;
+          }
+          event.currentTarget.dataset.fallbackApplied = "true";
+          event.currentTarget.src = "https://static.hdslb.com/images/member/noface.gif";
+        }}
+      />
+      <div className={`${SCRIPT_ID}-person-main`}>
+        <a
+          className={`${SCRIPT_ID}-name`}
+          href={`https://space.bilibili.com/${user.mid}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {user.name}
+        </a>
+        <div className={`${SCRIPT_ID}-meta`}>{user.meta || `UID ${user.mid}`}</div>
+      </div>
+      <div className={`${SCRIPT_ID}-check`} />
     </div>
-    <div className={`${SCRIPT_ID}-check`} />
-  </button>
-);
+  );
+};

--- a/scripts/bilibili-share-to-friends/src/components/user-list-item/style.css
+++ b/scripts/bilibili-share-to-friends/src/components/user-list-item/style.css
@@ -3,6 +3,7 @@
   grid-template-columns: 36px 1fr auto;
   align-items: center;
   gap: 9px;
+  box-sizing: border-box;
   width: 100%;
   padding: 8px 14px;
   border: 0;
@@ -25,13 +26,26 @@
   background: #e3e5e7;
 }
 
-.bili-share-to-friends-name {
+.bili-share-to-friends-person-main {
   min-width: 0;
+}
+
+.bili-share-to-friends-name {
+  display: inline-block;
+  min-width: 0;
+  max-width: 100%;
   font-size: 14px;
   color: #18191c;
+  text-decoration: none;
+  vertical-align: top;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+.bili-share-to-friends-name:hover,
+.bili-share-to-friends-name:focus-visible {
+  color: #00aeec;
 }
 
 .bili-share-to-friends-meta {

--- a/scripts/bilibili-share-to-friends/src/components/user-list/style.css
+++ b/scripts/bilibili-share-to-friends/src/components/user-list/style.css
@@ -1,6 +1,7 @@
 .bili-share-to-friends-list-scroll {
   flex: 1;
   min-height: 0;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- 点击用户列表昵称时新开标签页跳转到对应 B 站用户主页
- 保留列表项点击选中行为，并避免昵称点击误触发选中
- 将“我的关注 / 我的粉丝”筛选 radio 调整为与用户列表选中圆点一致的视觉风格

## Validation
- pnpm --filter @tampermonkey-scripts/bilibili-share-to-friends build
- pnpm lint
- pnpm -r test