### PR TITLE
refactor: 简化 B站好友分享用户选择项点击逻辑

### DIFF
--- a/scripts/bilibili-share-to-friends/dist/bilibili-share-to-friends.user.js
+++ b/scripts/bilibili-share-to-friends/dist/bilibili-share-to-friends.user.js
@@ -113,7 +113,7 @@
 }
 
 .bili-share-to-friends-person:hover,
-.bili-share-to-friends-person[aria-selected="true"] {
+.bili-share-to-friends-person[data-selected="true"] {
   background: #f6fbff;
 }
 
@@ -164,84 +164,84 @@
   border-radius: 50%;
 }
 
-.bili-share-to-friends-person[aria-selected="true"] .bili-share-to-friends-check {
+.bili-share-to-friends-person[data-selected="true"] .bili-share-to-friends-check {
   border-color: #00aeec;
   background: radial-gradient(circle at center, #00aeec 0 45%, transparent 47%);
 }
-.bili-share-to-friends-list-scroll {
-  flex: 1;
-  min-height: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-
-.bili-share-to-friends-list {
-  margin: 0;
-  padding: 5px 0;
-  list-style: none;
-}
-
-.bili-share-to-friends-list-footer {
-  min-height: 24px;
-  padding: 0 14px 6px;
-  color: #9499a0;
-  font-size: 12px;
-  line-height: 24px;
-  text-align: center;
-}
-
-.bili-share-to-friends-list-retry {
-  border: 0;
-  background: transparent;
-  color: #00aeec;
-  cursor: pointer;
-}
-
-.bili-share-to-friends-list-sentinel {
-  height: 1px;
-}
+.bili-share-to-friends-list-scroll {\r
+  flex: 1;\r
+  min-height: 0;\r
+  overflow-x: hidden;\r
+  overflow-y: auto;\r
+}\r
+\r
+.bili-share-to-friends-list {\r
+  margin: 0;\r
+  padding: 5px 0;\r
+  list-style: none;\r
+}\r
+\r
+.bili-share-to-friends-list-footer {\r
+  min-height: 24px;\r
+  padding: 0 14px 6px;\r
+  color: #9499a0;\r
+  font-size: 12px;\r
+  line-height: 24px;\r
+  text-align: center;\r
+}\r
+\r
+.bili-share-to-friends-list-retry {\r
+  border: 0;\r
+  background: transparent;\r
+  color: #00aeec;\r
+  cursor: pointer;\r
+}\r
+\r
+.bili-share-to-friends-list-sentinel {\r
+  height: 1px;\r
+}\r
 .bili-share-to-friends-panel {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
   min-height: 0;
 }
-.bili-share-to-friends-dialog::backdrop {
-  background: rgba(0, 0, 0, 0.38);
-}
-
-.bili-share-to-friends-dialog:not([open]) {
-  display: none !important;
-  pointer-events: none !important;
-}
-
-.bili-share-to-friends-dialog {
-  display: flex;
-  flex-direction: column;
-  width: min(420px, calc(100vw - 32px));
-  height: min(620px, calc(100vh - 48px));
-  max-height: calc(100vh - 48px);
-  padding: 0;
-  border: 0;
-  border-radius: 8px;
-  background: #fff;
-  color: #18191c;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
-  overflow: hidden;
-  font:
-    14px/1.5 -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    "Microsoft YaHei",
-    sans-serif;
-}
-
-.bili-share-to-friends-dialog-content {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  min-height: 0;
-}
+.bili-share-to-friends-dialog::backdrop {\r
+  background: rgba(0, 0, 0, 0.38);\r
+}\r
+\r
+.bili-share-to-friends-dialog:not([open]) {\r
+  display: none !important;\r
+  pointer-events: none !important;\r
+}\r
+\r
+.bili-share-to-friends-dialog {\r
+  display: flex;\r
+  flex-direction: column;\r
+  width: min(420px, calc(100vw - 32px));\r
+  height: min(620px, calc(100vh - 48px));\r
+  max-height: calc(100vh - 48px);\r
+  padding: 0;\r
+  border: 0;\r
+  border-radius: 8px;\r
+  background: #fff;\r
+  color: #18191c;\r
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);\r
+  overflow: hidden;\r
+  font:\r
+    14px/1.5 -apple-system,\r
+    BlinkMacSystemFont,\r
+    "Segoe UI",\r
+    "Microsoft YaHei",\r
+    sans-serif;\r
+}\r
+\r
+.bili-share-to-friends-dialog-content {\r
+  display: flex;\r
+  flex: 1 1 auto;\r
+  flex-direction: column;\r
+  min-height: 0;\r
+}\r
 .bili-share-to-friends-footer {
   display: flex;
   align-items: center;
@@ -631,6 +631,7 @@
     return url;
   };
   const SCRIPT_ID = "bili-share-to-friends";
+  const DEFAULT_AVATAR_URL = "https://static.hdslb.com/images/member/noface.gif";
   const DEV_ID_KEY = `${SCRIPT_ID}.dev_id`;
   const SESSION_CACHE_KEY = `${SCRIPT_ID}.recent_sessions.v2`;
   const SESSION_CACHE_TTL = 5 * 60 * 1e3;
@@ -1505,30 +1506,13 @@ https://www.bilibili.com/video/${video.bvid}`
     ] });
   };
   const StateView = ({ text, isError = false }) => /* @__PURE__ */ u$1("div", { className: `${SCRIPT_ID}-state${isError ? ` ${SCRIPT_ID}-state-error` : ""}`, children: text });
-  const isLinkTarget = (target) => target instanceof Element && Boolean(target.closest("a"));
   const UserListItem = ({ user, selected = false, onSelect }) => {
-    const handleSelect = (event) => {
-      if (isLinkTarget(event.target)) {
-        return;
-      }
-      onSelect(event.currentTarget, user);
-    };
-    const handleKeyDown = (event) => {
-      if (isLinkTarget(event.target) || event.key !== "Enter" && event.key !== " ") {
-        return;
-      }
-      event.preventDefault();
-      onSelect(event.currentTarget, user);
-    };
     return /* @__PURE__ */ u$1(
       "div",
       {
         className: `${SCRIPT_ID}-person`,
-        role: "button",
-        tabIndex: 0,
-        "aria-selected": String(selected),
-        onClick: handleSelect,
-        onKeyDown: handleKeyDown,
+        "data-selected": String(selected),
+        onClick: () => onSelect(user),
         children: [
           /* @__PURE__ */ u$1(
             "img",
@@ -1542,7 +1526,7 @@ https://www.bilibili.com/video/${video.bvid}`
                   return;
                 }
                 event.currentTarget.dataset.fallbackApplied = "true";
-                event.currentTarget.src = "https://static.hdslb.com/images/member/noface.gif";
+                event.currentTarget.src = DEFAULT_AVATAR_URL;
               }
             }
           ),
@@ -2170,7 +2154,7 @@ https://www.bilibili.com/video/${video.bvid}`
       },
       [activeTab, resetSelection]
     );
-    const handleUserSelect = q((_button, user) => {
+    const handleUserSelect = q((user) => {
       setSendError("");
       setSelectedUser(user);
     }, []);

--- a/scripts/bilibili-share-to-friends/src/components/user-list-item/UserListItem.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/user-list-item/UserListItem.jsx
@@ -1,37 +1,15 @@
-import { SCRIPT_ID } from "../../constants.js";
+import { DEFAULT_AVATAR_URL, SCRIPT_ID } from "../../constants.js";
 import "./style.css";
-
-const isLinkTarget = (target) => target instanceof Element && Boolean(target.closest("a"));
 
 /**
  * 渲染带用户主页链接的单个可选择用户行。
  */
 export const UserListItem = ({ user, selected = false, onSelect }) => {
-  const handleSelect = (event) => {
-    if (isLinkTarget(event.target)) {
-      return;
-    }
-
-    onSelect(event.currentTarget, user);
-  };
-
-  const handleKeyDown = (event) => {
-    if (isLinkTarget(event.target) || (event.key !== "Enter" && event.key !== " ")) {
-      return;
-    }
-
-    event.preventDefault();
-    onSelect(event.currentTarget, user);
-  };
-
   return (
     <div
       className={`${SCRIPT_ID}-person`}
-      role="button"
-      tabIndex={0}
-      aria-selected={String(selected)}
-      onClick={handleSelect}
-      onKeyDown={handleKeyDown}
+      data-selected={String(selected)}
+      onClick={() => onSelect(user)}
     >
       <img
         className={`${SCRIPT_ID}-avatar`}
@@ -43,7 +21,7 @@ export const UserListItem = ({ user, selected = false, onSelect }) => {
             return;
           }
           event.currentTarget.dataset.fallbackApplied = "true";
-          event.currentTarget.src = "https://static.hdslb.com/images/member/noface.gif";
+          event.currentTarget.src = DEFAULT_AVATAR_URL;
         }}
       />
       <div className={`${SCRIPT_ID}-person-main`}>

--- a/scripts/bilibili-share-to-friends/src/components/user-list-item/style.css
+++ b/scripts/bilibili-share-to-friends/src/components/user-list-item/style.css
@@ -14,7 +14,7 @@
 }
 
 .bili-share-to-friends-person:hover,
-.bili-share-to-friends-person[aria-selected="true"] {
+.bili-share-to-friends-person[data-selected="true"] {
   background: #f6fbff;
 }
 
@@ -65,7 +65,7 @@
   border-radius: 50%;
 }
 
-.bili-share-to-friends-person[aria-selected="true"] .bili-share-to-friends-check {
+.bili-share-to-friends-person[data-selected="true"] .bili-share-to-friends-check {
   border-color: #00aeec;
   background: radial-gradient(circle at center, #00aeec 0 45%, transparent 47%);
 }

--- a/scripts/bilibili-share-to-friends/src/constants.js
+++ b/scripts/bilibili-share-to-friends/src/constants.js
@@ -1,6 +1,9 @@
 /** 脚本命名空间，用于 DOM 类名、存储键和日志。 */
 export const SCRIPT_ID = "bili-share-to-friends";
 
+/** 用户头像加载失败时使用的 B 站默认头像。 */
+export const DEFAULT_AVATAR_URL = "https://static.hdslb.com/images/member/noface.gif";
+
 /** 生成的 B 站私信设备 id 对应的本地存储键。 */
 export const DEV_ID_KEY = `${SCRIPT_ID}.dev_id`;
 

--- a/scripts/bilibili-share-to-friends/src/ui.jsx
+++ b/scripts/bilibili-share-to-friends/src/ui.jsx
@@ -47,7 +47,7 @@ export const ShareDialog = ({ dialog, video, nav = null, status = "", error = ""
     [activeTab, resetSelection]
   );
 
-  const handleUserSelect = useCallback((_button, user) => {
+  const handleUserSelect = useCallback((user) => {
     setSendError("");
     setSelectedUser(user);
   }, []);


### PR DESCRIPTION
## 变更内容

- 简化用户列表项点击逻辑，删除不再需要的链接目标检测和键盘选择处理。
- 将用户选择回调链收敛为只传递 `user`，移除未使用的 DOM 节点参数。
- 将头像加载失败时使用的默认头像 URL 提取到 `constants.js` 统一维护。
- 将用户项选中态标记从 `aria-selected` 改为 `data-selected`，避免在删除按钮键盘语义后保留不匹配的 ARIA 标记。
- 更新 `bilibili-share-to-friends` 构建产物。

## 验证

- `pnpm build:bilibili`
- `pnpm lint`
- `git push` 触发的 `pnpm -r test`