### PR TITLE
fix: bilibili-share-to-friends 修复关系列表切换分页与滚动状态

### DIFF
--- a/scripts/bilibili-share-to-friends/dist/bilibili-share-to-friends.user.js
+++ b/scripts/bilibili-share-to-friends/dist/bilibili-share-to-friends.user.js
@@ -1787,10 +1787,7 @@ https://www.bilibili.com/video/${video.bvid}`
       var _a, _b;
       (_a = loadMoreObserverRef.current) == null ? void 0 : _a.disconnect();
       loadMoreObserverRef.current = null;
-      if (!active) {
-        return;
-      }
-      if (!displayState.hasMore || displayLoading.loading || displayLoading.loadingMore) {
+      if (!active || !displayState.loaded || !displayState.hasMore || displayState.moreError || displayLoading.loading || displayLoading.loadingMore) {
         return;
       }
       const scrollRoot = (_b = panelRef.current) == null ? void 0 : _b.querySelector(LIST_SCROLL_SELECTOR);
@@ -1815,6 +1812,8 @@ https://www.bilibili.com/video/${video.bvid}`
       displayLoading.loading,
       displayLoading.loadingMore,
       displayState.hasMore,
+      displayState.loaded,
+      displayState.moreError,
       loadRelationUsers
     ]);
     const resetSelection = () => {

--- a/scripts/bilibili-share-to-friends/dist/bilibili-share-to-friends.user.js
+++ b/scripts/bilibili-share-to-friends/dist/bilibili-share-to-friends.user.js
@@ -16,50 +16,50 @@
 // @run-at       document-end
 // ==/UserScript==
 
-(n=>{if(typeof GM_addStyle=="function"){GM_addStyle(n);return}const e=document.createElement("style");e.textContent=n,document.head.append(e)})(` .bili-share-to-friends-body {
+(n=>{if(typeof GM_addStyle=="function"){GM_addStyle(n);return}const r=document.createElement("style");r.textContent=n,document.head.append(r)})(` .bili-share-to-friends-body {
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
 }
-.bili-share-to-friends-relation-filter {
-  display: flex;
-  gap: 18px;
-  flex: 0 0 auto;
-  padding: 7px 14px 1px;
-  color: #18191c;
-}
-
-.bili-share-to-friends-relation-option {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  cursor: pointer;
-}
-
-.bili-share-to-friends-relation-option input {
-  appearance: none;
-  box-sizing: border-box;
-  width: 15px;
-  height: 15px;
-  margin: 0;
-  border: 1px solid #c9ccd0;
-  border-radius: 50%;
-  background: #fff;
-  cursor: pointer;
-}
-
-.bili-share-to-friends-relation-option input:checked {
-  border-color: #00aeec;
-  background: radial-gradient(circle at center, #00aeec 0 43%, transparent 45%);
-}
-
-.bili-share-to-friends-relation-option input:focus-visible {
-  outline: 2px solid rgba(0, 174, 236, 0.2);
-  outline-offset: 2px;
-}
+.bili-share-to-friends-relation-filter {\r
+  display: flex;\r
+  gap: 18px;\r
+  flex: 0 0 auto;\r
+  padding: 7px 14px 1px;\r
+  color: #18191c;\r
+}\r
+\r
+.bili-share-to-friends-relation-option {\r
+  display: inline-flex;\r
+  align-items: center;\r
+  gap: 6px;\r
+  font-size: 13px;\r
+  cursor: pointer;\r
+}\r
+\r
+.bili-share-to-friends-relation-option input {\r
+  appearance: none;\r
+  box-sizing: border-box;\r
+  width: 15px;\r
+  height: 15px;\r
+  margin: 0;\r
+  border: 1px solid #c9ccd0;\r
+  border-radius: 50%;\r
+  background: #fff;\r
+  cursor: pointer;\r
+}\r
+\r
+.bili-share-to-friends-relation-option input:checked {\r
+  border-color: #00aeec;\r
+  background: radial-gradient(circle at center, #00aeec 0 43%, transparent 45%);\r
+}\r
+\r
+.bili-share-to-friends-relation-option input:focus-visible {\r
+  outline: 2px solid rgba(0, 174, 236, 0.2);\r
+  outline-offset: 2px;\r
+}\r
 .bili-share-to-friends-search {
   flex: 0 0 auto;
   padding: 6px 14px 3px;
@@ -97,77 +97,77 @@
 .bili-share-to-friends-state-error {
   color: #d03050;
 }
-.bili-share-to-friends-person {
-  display: grid;
-  grid-template-columns: 36px 1fr auto;
-  align-items: center;
-  gap: 9px;
-  box-sizing: border-box;
-  width: 100%;
-  padding: 8px 14px;
-  border: 0;
-  background: #fff;
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.bili-share-to-friends-person:hover,
-.bili-share-to-friends-person[data-selected="true"] {
-  background: #f6fbff;
-}
-
-.bili-share-to-friends-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  object-fit: cover;
-  background: #e3e5e7;
-}
-
-.bili-share-to-friends-person-main {
-  min-width: 0;
-}
-
-.bili-share-to-friends-name {
-  display: inline-block;
-  min-width: 0;
-  max-width: 100%;
-  font-size: 14px;
-  color: #18191c;
-  text-decoration: none;
-  vertical-align: top;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.bili-share-to-friends-name:hover,
-.bili-share-to-friends-name:focus-visible {
-  color: #00aeec;
-}
-
-.bili-share-to-friends-meta {
-  min-width: 0;
-  margin-top: 1px;
-  color: #9499a0;
-  font-size: 12px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.bili-share-to-friends-check {
-  width: 18px;
-  height: 18px;
-  border: 1px solid #c9ccd0;
-  border-radius: 50%;
-}
-
-.bili-share-to-friends-person[data-selected="true"] .bili-share-to-friends-check {
-  border-color: #00aeec;
-  background: radial-gradient(circle at center, #00aeec 0 45%, transparent 47%);
-}
+.bili-share-to-friends-person {\r
+  display: grid;\r
+  grid-template-columns: 36px 1fr auto;\r
+  align-items: center;\r
+  gap: 9px;\r
+  box-sizing: border-box;\r
+  width: 100%;\r
+  padding: 8px 14px;\r
+  border: 0;\r
+  background: #fff;\r
+  color: inherit;\r
+  text-align: left;\r
+  cursor: pointer;\r
+}\r
+\r
+.bili-share-to-friends-person:hover,\r
+.bili-share-to-friends-person[data-selected="true"] {\r
+  background: #f6fbff;\r
+}\r
+\r
+.bili-share-to-friends-avatar {\r
+  width: 36px;\r
+  height: 36px;\r
+  border-radius: 50%;\r
+  object-fit: cover;\r
+  background: #e3e5e7;\r
+}\r
+\r
+.bili-share-to-friends-person-main {\r
+  min-width: 0;\r
+}\r
+\r
+.bili-share-to-friends-name {\r
+  display: inline-block;\r
+  min-width: 0;\r
+  max-width: 100%;\r
+  font-size: 14px;\r
+  color: #18191c;\r
+  text-decoration: none;\r
+  vertical-align: top;\r
+  overflow: hidden;\r
+  white-space: nowrap;\r
+  text-overflow: ellipsis;\r
+}\r
+\r
+.bili-share-to-friends-name:hover,\r
+.bili-share-to-friends-name:focus-visible {\r
+  color: #00aeec;\r
+}\r
+\r
+.bili-share-to-friends-meta {\r
+  min-width: 0;\r
+  margin-top: 1px;\r
+  color: #9499a0;\r
+  font-size: 12px;\r
+  overflow: hidden;\r
+  white-space: nowrap;\r
+  text-overflow: ellipsis;\r
+}\r
+\r
+.bili-share-to-friends-check {\r
+  width: 18px;\r
+  height: 18px;\r
+  border: 1px solid #c9ccd0;\r
+  border-radius: 50%;\r
+}\r
+\r
+.bili-share-to-friends-person[data-selected="true"] .bili-share-to-friends-check {\r
+  border-color: #00aeec;\r
+  background: radial-gradient(circle at center, #00aeec 0 45%, transparent 47%);\r
+}\r
 .bili-share-to-friends-list-scroll {\r
   flex: 1;\r
   min-height: 0;\r
@@ -200,12 +200,12 @@
 .bili-share-to-friends-list-sentinel {\r
   height: 1px;\r
 }\r
-.bili-share-to-friends-panel {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  min-height: 0;
-}
+.bili-share-to-friends-panel {\r
+  display: flex;\r
+  flex: 1 1 auto;\r
+  flex-direction: column;\r
+  min-height: 0;\r
+}\r
 .bili-share-to-friends-dialog::backdrop {\r
   background: rgba(0, 0, 0, 0.38);\r
 }\r
@@ -369,35 +369,35 @@
   width: 22px;
   height: 22px;
 }
-.bili-share-to-friends-tabs {
-  display: flex;
-  gap: 8px;
-  flex: 0 0 auto;
-  padding: 7px 14px 8px;
-  background: #fff;
-}
-
-.bili-share-to-friends-tab {
-  height: 28px;
-  padding: 0 10px;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  background: transparent;
-  color: #61666d;
-  font-size: 13px;
-  cursor: pointer;
-}
-
-.bili-share-to-friends-tab:hover {
-  color: #00aeec;
-}
-
-.bili-share-to-friends-tab[aria-selected="true"] {
-  color: #00aeec;
-  border-color: #b8e8f8;
-  background: #f6fbff;
-  font-weight: 600;
-}
+.bili-share-to-friends-tabs {\r
+  display: flex;\r
+  gap: 8px;\r
+  flex: 0 0 auto;\r
+  padding: 7px 14px 8px;\r
+  background: #fff;\r
+}\r
+\r
+.bili-share-to-friends-tab {\r
+  height: 28px;\r
+  padding: 0 10px;\r
+  border: 1px solid transparent;\r
+  border-radius: 4px;\r
+  background: transparent;\r
+  color: #61666d;\r
+  font-size: 13px;\r
+  cursor: pointer;\r
+}\r
+\r
+.bili-share-to-friends-tab:hover {\r
+  color: #00aeec;\r
+}\r
+\r
+.bili-share-to-friends-tab[aria-selected="true"] {\r
+  color: #00aeec;\r
+  border-color: #b8e8f8;\r
+  background: #f6fbff;\r
+  font-weight: 600;\r
+}\r
 .bili-share-to-friends-video {
   display: grid;
   grid-template-columns: 80px 1fr;
@@ -1772,10 +1772,17 @@ https://www.bilibili.com/video/${video.bvid}`
       return () => debouncedSearch.cancel();
     }, [debouncedSearch]);
     y(() => {
-      if (active) {
+      if (active && !displayState.loaded && !displayState.error && !displayLoading.loading) {
         loadRelationUsers(activeRelation);
       }
-    }, [active, activeRelation, loadRelationUsers]);
+    }, [
+      active,
+      activeRelation,
+      displayLoading.loading,
+      displayState.error,
+      displayState.loaded,
+      loadRelationUsers
+    ]);
     y(() => {
       var _a, _b;
       (_a = loadMoreObserverRef.current) == null ? void 0 : _a.disconnect();
@@ -1872,7 +1879,6 @@ https://www.bilibili.com/video/${video.bvid}`
             }
             resetSelection();
             setActiveRelation(relation);
-            loadRelationUsers(relation);
           }
         }
       ),

--- a/scripts/bilibili-share-to-friends/dist/bilibili-share-to-friends.user.js
+++ b/scripts/bilibili-share-to-friends/dist/bilibili-share-to-friends.user.js
@@ -1614,6 +1614,11 @@ https://www.bilibili.com/video/${video.bvid}`
     const loadMoreObserverRef = A(null);
     const loadingKeysRef = A(/* @__PURE__ */ new Set());
     const pendingScrollTopRef = A(null);
+    const scrollTopMapRef = A({
+      following: 0,
+      followers: 0,
+      followingSearch: 0
+    });
     const [activeRelation, setActiveRelation] = d("following");
     const [searchTerm, setSearchTerm] = d("");
     const [relations, setRelations] = d(createRelationsState);
@@ -1652,6 +1657,11 @@ https://www.bilibili.com/video/${video.bvid}`
       setSearchTerm("");
       setRelations(createRelationsState());
       setFollowingSearch(createPageState());
+      scrollTopMapRef.current = {
+        following: 0,
+        followers: 0,
+        followingSearch: 0
+      };
       onSelectionReset();
     }, [mid, onSelectionReset]);
     _(() => {
@@ -1673,6 +1683,9 @@ https://www.bilibili.com/video/${video.bvid}`
       },
       []
     );
+    const saveCurrentScrollTop = q(() => {
+      scrollTopMapRef.current[displaySource] = getListScrollTop();
+    }, [displaySource, getListScrollTop]);
     const setPageState = q((source, updater) => {
       if (source === "followingSearch") {
         setFollowingSearch(updater);
@@ -1816,12 +1829,23 @@ https://www.bilibili.com/video/${video.bvid}`
       displayState.moreError,
       loadRelationUsers
     ]);
+    _(() => {
+      var _a;
+      if (!active) {
+        return;
+      }
+      const scrollRoot = (_a = panelRef.current) == null ? void 0 : _a.querySelector(LIST_SCROLL_SELECTOR);
+      if (scrollRoot) {
+        scrollRoot.scrollTop = scrollTopMapRef.current[displaySource] ?? 0;
+      }
+    }, [active, displaySource]);
     const resetSelection = () => {
       onSelectionReset();
     };
     const scheduleSearch = (value, { immediate = false } = {}) => {
       const previousKeyword = searchTerm.trim();
       const nextKeyword = value.trim();
+      saveCurrentScrollTop();
       setSearchTerm(value);
       if (previousKeyword === nextKeyword) {
         return;
@@ -1877,6 +1901,7 @@ https://www.bilibili.com/video/${video.bvid}`
               return;
             }
             resetSelection();
+            saveCurrentScrollTop();
             setActiveRelation(relation);
           }
         }

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -220,10 +220,17 @@ export const AllFriendsPanel = ({
   }, [debouncedSearch]);
 
   useEffect(() => {
-    if (active) {
+    if (active && !displayState.loaded && !displayState.error && !displayLoading.loading) {
       loadRelationUsers(activeRelation);
     }
-  }, [active, activeRelation, loadRelationUsers]);
+  }, [
+    active,
+    activeRelation,
+    displayLoading.loading,
+    displayState.error,
+    displayState.loaded,
+    loadRelationUsers,
+  ]);
 
   useEffect(() => {
     loadMoreObserverRef.current?.disconnect();
@@ -323,7 +330,6 @@ export const AllFriendsPanel = ({
           }
           resetSelection();
           setActiveRelation(relation);
-          loadRelationUsers(relation);
         }}
       />
       <SearchBox

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -235,10 +235,14 @@ export const AllFriendsPanel = ({
   useEffect(() => {
     loadMoreObserverRef.current?.disconnect();
     loadMoreObserverRef.current = null;
-    if (!active) {
-      return;
-    }
-    if (!displayState.hasMore || displayLoading.loading || displayLoading.loadingMore) {
+    if (
+      !active ||
+      !displayState.loaded ||
+      !displayState.hasMore ||
+      displayState.moreError ||
+      displayLoading.loading ||
+      displayLoading.loadingMore
+    ) {
       return;
     }
     const scrollRoot = panelRef.current?.querySelector(LIST_SCROLL_SELECTOR);
@@ -263,6 +267,8 @@ export const AllFriendsPanel = ({
     displayLoading.loading,
     displayLoading.loadingMore,
     displayState.hasMore,
+    displayState.loaded,
+    displayState.moreError,
     loadRelationUsers,
   ]);
 

--- a/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
+++ b/scripts/bilibili-share-to-friends/src/components/all-friends-panel/AllFriendsPanel.jsx
@@ -44,6 +44,11 @@ export const AllFriendsPanel = ({
   const loadMoreObserverRef = useRef(null);
   const loadingKeysRef = useRef(new Set());
   const pendingScrollTopRef = useRef(null);
+  const scrollTopMapRef = useRef({
+    following: 0,
+    followers: 0,
+    followingSearch: 0,
+  });
   const [activeRelation, setActiveRelation] = useState("following");
   const [searchTerm, setSearchTerm] = useState("");
   const [relations, setRelations] = useState(createRelationsState);
@@ -85,6 +90,11 @@ export const AllFriendsPanel = ({
     setSearchTerm("");
     setRelations(createRelationsState());
     setFollowingSearch(createPageState());
+    scrollTopMapRef.current = {
+      following: 0,
+      followers: 0,
+      followingSearch: 0,
+    };
     onSelectionReset();
   }, [mid, onSelectionReset]);
 
@@ -104,6 +114,10 @@ export const AllFriendsPanel = ({
     () => panelRef.current?.querySelector(LIST_SCROLL_SELECTOR)?.scrollTop ?? 0,
     []
   );
+
+  const saveCurrentScrollTop = useCallback(() => {
+    scrollTopMapRef.current[displaySource] = getListScrollTop();
+  }, [displaySource, getListScrollTop]);
 
   const setPageState = useCallback((source, updater) => {
     if (source === "followingSearch") {
@@ -272,6 +286,16 @@ export const AllFriendsPanel = ({
     loadRelationUsers,
   ]);
 
+  useLayoutEffect(() => {
+    if (!active) {
+      return;
+    }
+    const scrollRoot = panelRef.current?.querySelector(LIST_SCROLL_SELECTOR);
+    if (scrollRoot) {
+      scrollRoot.scrollTop = scrollTopMapRef.current[displaySource] ?? 0;
+    }
+  }, [active, displaySource]);
+
   const resetSelection = () => {
     onSelectionReset();
   };
@@ -279,6 +303,7 @@ export const AllFriendsPanel = ({
   const scheduleSearch = (value, { immediate = false } = {}) => {
     const previousKeyword = searchTerm.trim();
     const nextKeyword = value.trim();
+    saveCurrentScrollTop();
     setSearchTerm(value);
     if (previousKeyword === nextKeyword) {
       return;
@@ -335,6 +360,7 @@ export const AllFriendsPanel = ({
             return;
           }
           resetSelection();
+          saveCurrentScrollTop();
           setActiveRelation(relation);
         }}
       />


### PR DESCRIPTION
## 变更内容

- 修复“我的关注 / 我的粉丝”切换时，已加载过的关系列表会自动请求下一页的问题。
- 保留 sentinel + IntersectionObserver 的分页加载方式，并收紧观察器启用条件，避免在列表未加载或加载更多失败时继续挂载观察器。
- 为“我的关注”“我的粉丝”和关注搜索结果分别保存滚动位置，切换回来时恢复到离开前的位置。
- 同步更新 `scripts/bilibili-share-to-friends/dist/bilibili-share-to-friends.user.js` 发布产物。

## 修复原因

原实现中，关系切换会直接调用加载函数，同时 `activeRelation` 变化后 effect 也会再次调用加载函数。对于已加载且仍有更多数据的列表，这会被当作加载下一页处理。另外列表切换会重渲染滚动容器，浏览器不会为不同关系列表自动保留独立滚动位置。

## 验证

- `pnpm lint`
- `pnpm build:bilibili`
- `pnpm -r test`