### PR TITLE
统一脚本元数据复用 package 信息

### DIFF
--- a/scripts/beautify-code-block-font-style/package.json
+++ b/scripts/beautify-code-block-font-style/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tampermonkey-scripts/beautify-code-block-font-style",
   "version": "0.5.1",
+  "displayName": "改变网页代码块的字体样式",
   "description": "改变网页代码块的字体样式，LeetCode、CSDN、掘金、博客园的代码块字体全被设置为Cascadia Code这款字体，后面还有YaHei Consolas Hybrid和Lucida Console这两款字体做候选，最后由CSDN代码块的字体样式兜底",
   "author": "LiarCoder",
   "private": true,

--- a/scripts/beautify-code-block-font-style/src/meta.js
+++ b/scripts/beautify-code-block-font-style/src/meta.js
@@ -2,12 +2,12 @@ import { buildRawScriptUrl } from "@tampermonkey-scripts/shared";
 
 import packageJson from "../package.json";
 
-const { author, description, scriptName, version } = packageJson;
+const { author, description, displayName, scriptName, version } = packageJson;
 
 const rawScriptUrl = buildRawScriptUrl(scriptName);
 
 export const userscript = {
-  name: "改变网页代码块的字体样式",
+  name: displayName,
   namespace: "http://tampermonkey.net/",
   version,
   description,

--- a/scripts/bilibili-share-to-friends/package.json
+++ b/scripts/bilibili-share-to-friends/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tampermonkey-scripts/bilibili-share-to-friends",
   "version": "0.4.8",
+  "displayName": "B站视频分享给好友",
+  "description": "在 Bilibili 视频播放页的原分享面板中新增“B站好友”入口，将当前视频以文本链接私信发送给最近聊天、关注或粉丝用户",
+  "author": "LiarCoder",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/bilibili-share-to-friends/src/meta.js
+++ b/scripts/bilibili-share-to-friends/src/meta.js
@@ -2,15 +2,16 @@ import { buildRawScriptUrl } from "@tampermonkey-scripts/shared";
 
 import packageJson from "../package.json";
 
-const rawScriptUrl = buildRawScriptUrl(packageJson.scriptName);
+const { author, description, displayName, scriptName, version } = packageJson;
+
+const rawScriptUrl = buildRawScriptUrl(scriptName);
 
 export const userscript = {
-  name: "B站视频分享给好友",
+  name: displayName,
   namespace: "http://tampermonkey.net/",
-  version: packageJson.version,
-  description:
-    "在 Bilibili 视频播放页的原分享面板中新增“B站好友”入口，将当前视频以文本链接私信发送给最近聊天、关注或粉丝用户",
-  author: "LiarCoder",
+  version,
+  description,
+  author,
   icon: "https://www.bilibili.com/favicon.ico",
   updateURL: rawScriptUrl,
   downloadURL: rawScriptUrl,

--- a/scripts/copy-title-and-location/dist/copy-title-and-location.user.js
+++ b/scripts/copy-title-and-location/dist/copy-title-and-location.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         复制标题和地址
 // @namespace    http://tampermonkey.net/
-// @version      0.7
+// @version      0.7.0
 // @author       LiarCoder
 // @description  一键复制标题和地址为Markdown格式并带上当前时间（myFirstScript）
 // @icon         data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABTklEQVQ4jY3TO0tcURQF4G/ixFdhCIg2qWysZPwDsUkXSJk2Qso0IpLOTtLERkGwEjQhXV5d0gkGK6v7E/IHgg9EHR0nHLLvzGHujGbB5pzLOXvttfc6twaNRiMta1g1GG28xJfyRlEU6rF/FskpjvA4o7nABD7gM17hY3lYEjzHOd4NqP8QW3gURA+wJzYJI2hV0rq4xtfsexdPcwW3EQmLaSw4wVCQr+M1DtDEJt7iVz1jLRUsB0GOn9iPymWRJ7mChOFY5ysNVFHrHaKwKWEGUyG1HZcnMY4/0UarH0Ez1u+Yq9T8h5tw5BTTg1p4EYfNnuR6WC3srCgo+/odcRdK+7ubrGIRvfeLq7hz3KsgESXPE97HDFKfOUazxLFegst4MAmf7pGfkP6NNNAOwTesYAM/YkgdrzOcYRYLeJMTHMbTTE926T8U7GAb/gI+kkP5n3CsvwAAAABJRU5ErkJggg==

--- a/scripts/copy-title-and-location/package.json
+++ b/scripts/copy-title-and-location/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tampermonkey-scripts/copy-title-and-location",
   "version": "0.7.0",
+  "displayName": "复制标题和地址",
+  "description": "一键复制标题和地址为Markdown格式并带上当前时间（myFirstScript）",
+  "author": "LiarCoder",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/copy-title-and-location/src/meta.js
+++ b/scripts/copy-title-and-location/src/meta.js
@@ -2,14 +2,16 @@ import { buildRawScriptUrl } from "@tampermonkey-scripts/shared";
 
 import packageJson from "../package.json";
 
-const rawScriptUrl = buildRawScriptUrl(packageJson.scriptName);
+const { author, description, displayName, scriptName, version } = packageJson;
+
+const rawScriptUrl = buildRawScriptUrl(scriptName);
 
 export const userscript = {
-  name: "复制标题和地址",
+  name: displayName,
   namespace: "http://tampermonkey.net/",
-  version: "0.7",
-  description: "一键复制标题和地址为Markdown格式并带上当前时间（myFirstScript）",
-  author: "LiarCoder",
+  version,
+  description,
+  author,
   updateURL: rawScriptUrl,
   downloadURL: rawScriptUrl,
   match: "*://*/*",

--- a/scripts/juejin-markdown-formatter/package.json
+++ b/scripts/juejin-markdown-formatter/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tampermonkey-scripts/juejin-markdown-formatter",
   "version": "0.3.3",
+  "displayName": "掘金Markdown格式适配器",
+  "description": "掘金Markdown编辑器适配脚本：从本地导入Markdown文件，并对文档做一些处理：居中图片、居中图片标注的文字、解决==无法高亮的问题、自动填充标题",
+  "author": "LiarCoder",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/juejin-markdown-formatter/src/meta.js
+++ b/scripts/juejin-markdown-formatter/src/meta.js
@@ -2,15 +2,16 @@ import { buildRawScriptUrl } from "@tampermonkey-scripts/shared";
 
 import packageJson from "../package.json";
 
-const rawScriptUrl = buildRawScriptUrl(packageJson.scriptName);
+const { author, description, displayName, scriptName, version } = packageJson;
+
+const rawScriptUrl = buildRawScriptUrl(scriptName);
 
 export const userscript = {
-  name: "掘金Markdown格式适配器",
+  name: displayName,
   namespace: "http://tampermonkey.net/",
-  version: "0.3.3",
-  description:
-    "掘金Markdown编辑器适配脚本：从本地导入Markdown文件，并对文档做一些处理：居中图片、居中图片标注的文字、解决==无法高亮的问题、自动填充标题",
-  author: "LiarCoder",
+  version,
+  description,
+  author,
   updateURL: rawScriptUrl,
   downloadURL: rawScriptUrl,
   match: "https://juejin.cn/editor/*",

--- a/scripts/just-jump-ahead/package.json
+++ b/scripts/just-jump-ahead/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tampermonkey-scripts/just-jump-ahead",
   "version": "0.3.3",
+  "displayName": "JustJumpAhead",
+  "description": "自动完成掘金、简书、知乎、百度贴吧、PC端QQ、CSDN、Gitee的跳转询问界面的点击工作，实现自动跳转",
+  "author": "LiarCoder",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/just-jump-ahead/src/meta.js
+++ b/scripts/just-jump-ahead/src/meta.js
@@ -2,15 +2,16 @@ import { buildRawScriptUrl } from "@tampermonkey-scripts/shared";
 
 import packageJson from "../package.json";
 
-const rawScriptUrl = buildRawScriptUrl(packageJson.scriptName);
+const { author, description, displayName, scriptName, version } = packageJson;
+
+const rawScriptUrl = buildRawScriptUrl(scriptName);
 
 export const userscript = {
-  name: "JustJumpAhead",
+  name: displayName,
   namespace: "http://tampermonkey.net/",
-  version: "0.3.3",
-  description:
-    "自动完成掘金、简书、知乎、百度贴吧、PC端QQ、CSDN、Gitee的跳转询问界面的点击工作，实现自动跳转",
-  author: "LiarCoder",
+  version,
+  description,
+  author,
   updateURL: rawScriptUrl,
   downloadURL: rawScriptUrl,
   match: [

--- a/scripts/pr-checker/dist/pr-checker.user.js
+++ b/scripts/pr-checker/dist/pr-checker.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PR三思器
 // @namespace    http://tampermonkey.net/
-// @version      V1.3.0
+// @version      1.3.0
 // @author       liaw
 // @description  创建PR前，提醒一下有没有一些遗漏的东西需要检查
 // @license      MIT

--- a/scripts/pr-checker/package.json
+++ b/scripts/pr-checker/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tampermonkey-scripts/pr-checker",
   "version": "1.3.0",
+  "displayName": "PR三思器",
+  "description": "创建PR前，提醒一下有没有一些遗漏的东西需要检查",
+  "author": "liaw",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/pr-checker/src/meta.js
+++ b/scripts/pr-checker/src/meta.js
@@ -2,14 +2,16 @@ import { buildRawScriptUrl } from "@tampermonkey-scripts/shared";
 
 import packageJson from "../package.json";
 
-const rawScriptUrl = buildRawScriptUrl(packageJson.scriptName);
+const { author, description, displayName, scriptName, version } = packageJson;
+
+const rawScriptUrl = buildRawScriptUrl(scriptName);
 
 export const userscript = {
-  name: "PR三思器",
+  name: displayName,
   namespace: "http://tampermonkey.net/",
-  version: "V1.3.0",
-  description: "创建PR前，提醒一下有没有一些遗漏的东西需要检查",
-  author: "liaw",
+  version,
+  description,
+  author,
   updateURL: rawScriptUrl,
   downloadURL: rawScriptUrl,
   match: ["https://code.fineres.com/*/pull-requests?create*"],


### PR DESCRIPTION
## 变更内容

- 为 `scripts` 下各脚本的 `package.json` 补充 `displayName`、`description`、`author` 元数据。
- 统一各脚本 `src/meta.js` 的写法，从 package 元数据中复用 `displayName`、`version`、`description`、`author` 和 `scriptName`。
- 保留 userscript 专属配置在 `meta.js` 中，例如 `namespace`、`match`、`grant`、`icon`、`connect`、`run-at` 等。
- 重新构建受影响脚本产物；`copy-title-and-location` 的 `@version` 跟随 package 规范为 `0.7.0`，`pr-checker` 的 `@version` 跟随 package 规范为 `1.3.0`。

## 影响范围

- 不改业务逻辑，只调整元数据来源和构建产物头部。
- npm 包名不作为 userscript 展示名使用，展示名统一放在 `displayName`。

## 验证

- `pnpm build`
- `pnpm exec eslint scripts/*/src/meta.js`
- `pnpm exec prettier --check scripts/*/package.json scripts/*/src/meta.js`
- `pnpm -r test`
- `git diff --check`
- 抽查 `dist/*.user.js` 头部的 `@name`、`@version`、`@author`、`@description`